### PR TITLE
Add getitem-profiler skill: line-level Dataset.__getitem__ optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-market
 
 Skills bundle for HPC-based ML research:
 
-- **`slurm`** — Submit, monitor, and debug SLURM jobs; pick partitions; tune batch size; diagnose OOM/timeout/node errors. Auto-detects the cluster via `scontrol` and loads the matching site reference from `slurm/clusters/` — ships with references for **NCSA Delta** (partitions, charge rates, `/work` vs `/projects`, `bdhi` account) and **University of Utah CHPC** (account/partition/QOS triples, module system, scratch filesystems). Add another cluster by dropping a new file into `slurm/clusters/<name>.md` and updating the detection table in `slurm/SKILL.md`.
+- **`slurm`** — Submit, monitor, and debug SLURM jobs; pick partitions; tune batch size; diagnose OOM/timeout/node errors. Auto-detects the cluster via `scontrol` and loads the matching site reference from `slurm/clusters/` — ships with references for **NCSA Delta** (partitions, charge rates, `/work` vs `/projects`, account conventions) and **University of Utah CHPC** (account/partition/QOS triples, module system, scratch filesystems). Add another cluster by dropping a new file into `slurm/clusters/<name>.md` and updating the detection table in `slurm/SKILL.md`.
 - **`model-training`** — Staged pre-flight test procedure (code correctness → learnability → GPU efficiency → fault tolerance) to shake out a training loop before launching a full run.
 - **`autoresearch`** — Autonomous iteration on model architecture, data augmentation, and objective functions via rapid small-scale experiments.
 

--- a/docs/superpowers/plans/2026-04-24-autoresearch-redesign.md
+++ b/docs/superpowers/plans/2026-04-24-autoresearch-redesign.md
@@ -1,0 +1,1216 @@
+# Autoresearch redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current `ml-research:autoresearch` skill with a thin orchestrator that dispatches three specialized subagents (Ideator, Experimenter, Reviewer), per the design at `docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md`.
+
+**Architecture:** Move the deep ML-research expertise out of `SKILL.md` and into three new agent definition files in `plugins/ml-research/agents/`. The new SKILL.md becomes a state-machine dispatcher with a Phase 0 setup dialog and a Phase 1 loop. Per-campaign state lives in a worktree at `../autoresearch-<project_name>/autoresearch/` with one experiment file per experiment, plus a frozen `config.json`.
+
+**Tech Stack:** Markdown with YAML frontmatter (skills + agents), JSON (config.json template), CSV (results), Bash for scaffolding scripts. No new code dependencies — the project's framework choices are pluggable via user-provided entrypoints.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md` is the source of truth for any detail not spelled out in this plan. When authoring the agent files in particular, cross-reference the spec sections noted in each task.
+
+---
+
+## File structure
+
+After this plan completes:
+
+```
+plugins/ml-research/
+├── .claude-plugin/plugin.json                    # unchanged
+├── agents/                                       # NEW dir
+│   ├── autoresearch-ideator.md                   # NEW
+│   ├── autoresearch-experimenter.md              # NEW
+│   └── autoresearch-reviewer.md                  # NEW
+└── skills/autoresearch/
+    ├── SKILL.md                                  # REWRITTEN
+    └── templates/
+        ├── config.json                           # NEW
+        ├── ideas.md                              # NEW (replaces autoresearch_ideas.md)
+        ├── insights.md                           # NEW
+        ├── results.csv                           # NEW (replaces autoresearch_results.csv)
+        └── examples/                             # NEW dir
+            ├── count_params_lightning.py         # MOVED from skills/autoresearch/scripts/count_params.py
+            ├── launch_slurm_lightning.sbatch     # MOVED from skills/autoresearch/scripts/launch.sbatch
+            └── lightning_trainer_config.yaml     # MOVED from skills/autoresearch/config.yaml
+```
+
+Removed:
+
+- `plugins/ml-research/skills/autoresearch/scripts/` (entire dir; both scripts moved to examples)
+- `plugins/ml-research/skills/autoresearch/config.yaml` (moved to examples)
+- `plugins/ml-research/skills/autoresearch/templates/autoresearch_ideas.md` (replaced)
+- `plugins/ml-research/skills/autoresearch/templates/autoresearch_log.md` (eliminated; replaced by per-experiment files)
+- `plugins/ml-research/skills/autoresearch/templates/autoresearch_results.csv` (replaced)
+
+---
+
+## Tasks
+
+### Task 0: Restructure files and directories
+
+**Goal:** Move existing scripts/templates/config to the new examples/ layout, create the new directories, and delete the old templates that are being replaced.
+
+**Files:**
+- Create dir: `plugins/ml-research/agents/`
+- Create dir: `plugins/ml-research/skills/autoresearch/templates/examples/`
+- Move: `plugins/ml-research/skills/autoresearch/scripts/count_params.py` → `plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py`
+- Move: `plugins/ml-research/skills/autoresearch/scripts/launch.sbatch` → `plugins/ml-research/skills/autoresearch/templates/examples/launch_slurm_lightning.sbatch`
+- Move: `plugins/ml-research/skills/autoresearch/config.yaml` → `plugins/ml-research/skills/autoresearch/templates/examples/lightning_trainer_config.yaml`
+- Delete: `plugins/ml-research/skills/autoresearch/scripts/` (now empty)
+- Delete: `plugins/ml-research/skills/autoresearch/templates/autoresearch_ideas.md`
+- Delete: `plugins/ml-research/skills/autoresearch/templates/autoresearch_log.md`
+- Delete: `plugins/ml-research/skills/autoresearch/templates/autoresearch_results.csv`
+
+**Acceptance Criteria:**
+- [ ] `plugins/ml-research/agents/` exists and is empty
+- [ ] `plugins/ml-research/skills/autoresearch/templates/examples/` contains exactly three files: `count_params_lightning.py`, `launch_slurm_lightning.sbatch`, `lightning_trainer_config.yaml`
+- [ ] `plugins/ml-research/skills/autoresearch/scripts/` no longer exists
+- [ ] `plugins/ml-research/skills/autoresearch/config.yaml` no longer exists at that path
+- [ ] No file under `plugins/ml-research/skills/autoresearch/templates/` has the `autoresearch_` prefix anymore (those are gone)
+
+**Verify:**
+```bash
+test -d plugins/ml-research/agents/ \
+  && test -f plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py \
+  && test -f plugins/ml-research/skills/autoresearch/templates/examples/launch_slurm_lightning.sbatch \
+  && test -f plugins/ml-research/skills/autoresearch/templates/examples/lightning_trainer_config.yaml \
+  && ! test -d plugins/ml-research/skills/autoresearch/scripts/ \
+  && ! test -f plugins/ml-research/skills/autoresearch/config.yaml \
+  && ! ls plugins/ml-research/skills/autoresearch/templates/autoresearch_* 2>/dev/null \
+  && echo OK
+```
+Expected output: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Move the scripts and config into the examples directory using `git mv` to preserve history**
+
+```bash
+mkdir -p plugins/ml-research/skills/autoresearch/templates/examples
+git mv plugins/ml-research/skills/autoresearch/scripts/count_params.py \
+       plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py
+git mv plugins/ml-research/skills/autoresearch/scripts/launch.sbatch \
+       plugins/ml-research/skills/autoresearch/templates/examples/launch_slurm_lightning.sbatch
+git mv plugins/ml-research/skills/autoresearch/config.yaml \
+       plugins/ml-research/skills/autoresearch/templates/examples/lightning_trainer_config.yaml
+```
+
+- [ ] **Step 2: Remove the now-empty scripts directory**
+
+```bash
+rmdir plugins/ml-research/skills/autoresearch/scripts/
+```
+
+- [ ] **Step 3: Delete the old templates that are being replaced**
+
+```bash
+git rm plugins/ml-research/skills/autoresearch/templates/autoresearch_ideas.md \
+       plugins/ml-research/skills/autoresearch/templates/autoresearch_log.md \
+       plugins/ml-research/skills/autoresearch/templates/autoresearch_results.csv
+```
+
+- [ ] **Step 4: Create the agents directory with a `.gitkeep` so it's tracked even while empty**
+
+```bash
+mkdir -p plugins/ml-research/agents
+touch plugins/ml-research/agents/.gitkeep
+git add plugins/ml-research/agents/.gitkeep
+```
+
+- [ ] **Step 5: Run the verify command**
+
+```bash
+test -d plugins/ml-research/agents/ \
+  && test -f plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py \
+  && test -f plugins/ml-research/skills/autoresearch/templates/examples/launch_slurm_lightning.sbatch \
+  && test -f plugins/ml-research/skills/autoresearch/templates/examples/lightning_trainer_config.yaml \
+  && ! test -d plugins/ml-research/skills/autoresearch/scripts/ \
+  && ! test -f plugins/ml-research/skills/autoresearch/config.yaml \
+  && ! ls plugins/ml-research/skills/autoresearch/templates/autoresearch_* 2>/dev/null \
+  && echo OK
+```
+Expected: `OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A plugins/ml-research/
+git commit -m "Restructure autoresearch: move scripts to examples/, drop autoresearch_ prefix templates"
+```
+
+---
+
+### Task 1: Write new template files
+
+**Goal:** Create the four campaign-initialization templates that Phase 0 setup will copy/scaffold into a new worktree.
+
+**Files:**
+- Create: `plugins/ml-research/skills/autoresearch/templates/config.json`
+- Create: `plugins/ml-research/skills/autoresearch/templates/ideas.md`
+- Create: `plugins/ml-research/skills/autoresearch/templates/insights.md`
+- Create: `plugins/ml-research/skills/autoresearch/templates/results.csv`
+
+**Acceptance Criteria:**
+- [ ] `templates/config.json` is valid JSON and matches the schema in spec § "Data model → autoresearch/config.json"
+- [ ] `templates/config.json` uses placeholder values that signal "needs to be filled in by Phase 0" (not real defaults)
+- [ ] `templates/ideas.md` has a comment header explaining FIFO user-input semantics
+- [ ] `templates/insights.md` has the four section headings from spec (Patterns observed, Anti-patterns, Open questions, Closed directions)
+- [ ] `templates/results.csv` contains exactly the header row from spec, no data rows
+- [ ] Every file ends with a trailing newline
+
+**Verify:**
+```bash
+python3 -c "import json; json.load(open('plugins/ml-research/skills/autoresearch/templates/config.json'))" \
+  && grep -q "FIFO" plugins/ml-research/skills/autoresearch/templates/ideas.md \
+  && grep -q "## Patterns observed" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && grep -q "## Anti-patterns" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && grep -q "## Open questions" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && grep -q "## Closed directions" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && head -1 plugins/ml-research/skills/autoresearch/templates/results.csv \
+       | grep -q "^experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss$" \
+  && echo OK
+```
+Expected output: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Write `templates/config.json`** (this is a *template stub* — Phase 0 setup will fill in the real values; placeholders below are explicit `"<placeholder>"` strings to make it obvious to a human reader that it needs filling in)
+
+```json
+{
+  "project_name": "<set by Phase 0 — should match the worktree suffix>",
+  "relevant_files": {
+    "read_only": [],
+    "editable": []
+  },
+  "entrypoints": {
+    "count_params": {
+      "command": "<command that prints {trainable_params, total_params} JSON to stdout>"
+    },
+    "launch_experiment": {
+      "command": "<command that submits a job and prints the job ID to stdout>",
+      "environment": "<one of: slurm | local | k8s | ray | ...>"
+    },
+    "read_metrics": {
+      "command": "<command that prints {final_train_loss, final_val_loss, ...} JSON to stdout, given $JOB_ID env var>"
+    }
+  },
+  "experiment_budget": {
+    "max_steps": 0,
+    "max_wall_time": "00:00:00"
+  },
+  "compile_cache_dir": null,
+  "debug_cap": 3,
+  "constraints": [
+    "no change to random seed, validation dataset, validation logic, or validation metrics",
+    "no change to the experiment budget defined in config.json (experiment_budget)",
+    "parameter count must be <= baseline * 1.05",
+    "no change to core dependencies / package versions"
+  ],
+  "theme_priorities": {
+    "high": [],
+    "medium": [],
+    "low": []
+  },
+  "prior_findings": []
+}
+```
+
+- [ ] **Step 2: Write `templates/ideas.md`**
+
+```markdown
+# User-suggested ideas (FIFO)
+
+<!--
+This file is a user-input buffer for autoresearch. Add an idea by writing a
+new H2 section anywhere in this file. The main agent processes ideas
+top-to-bottom; the section is removed once the idea is dispatched as an
+experiment.
+
+Per-idea format (any keys missing are inferred or left blank):
+
+## Short title for the idea
+- theme: optimizer | initialization | data_augmentation | architecture | regularization | training_objective | tokenization | schedule | <other>
+- rationale: 1-2 sentences on why
+- expected: 1-2 sentences on the predicted outcome (optional)
+
+This file is initially empty. The autoresearch loop's Ideator subagent
+generates ideas autonomously when this buffer is empty; this file exists
+solely so a human can inject a specific idea at the front of the queue.
+-->
+```
+
+- [ ] **Step 3: Write `templates/insights.md`**
+
+```markdown
+# Insights
+
+<!--
+Reviewer-maintained synthesis of cross-experiment patterns. The Reviewer
+subagent updates this file every 5 succeeded experiments. Each insight
+should be grounded in specific experiment IDs (e.g., "exp 014, 019, 021").
+
+Sections below are the standard taxonomy. Reviewer may add subsections
+within them but should not introduce new top-level sections.
+-->
+
+## Patterns observed
+
+<!-- Confirmed positive patterns with experiment-ID grounding -->
+
+## Anti-patterns
+
+<!-- Confirmed negative patterns with experiment-ID grounding;
+     also: ideas that look like proxy-overfit wins -->
+
+## Open questions
+
+<!-- Hypotheses worth testing; conflicting signals across experiments -->
+
+## Closed directions
+
+<!-- Themes/approaches the campaign has decided not to pursue further -->
+```
+
+- [ ] **Step 4: Write `templates/results.csv`**
+
+```
+experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss
+```
+
+(Single line — the header. No data rows. Ensure a trailing newline at the end of file.)
+
+- [ ] **Step 5: Run the verify command**
+
+```bash
+python3 -c "import json; json.load(open('plugins/ml-research/skills/autoresearch/templates/config.json'))" \
+  && grep -q "FIFO" plugins/ml-research/skills/autoresearch/templates/ideas.md \
+  && grep -q "## Patterns observed" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && grep -q "## Anti-patterns" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && grep -q "## Open questions" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && grep -q "## Closed directions" plugins/ml-research/skills/autoresearch/templates/insights.md \
+  && head -1 plugins/ml-research/skills/autoresearch/templates/results.csv \
+       | grep -q "^experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss$" \
+  && echo OK
+```
+Expected: `OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ml-research/skills/autoresearch/templates/
+git commit -m "Add autoresearch campaign templates (config.json, ideas.md, insights.md, results.csv)"
+```
+
+---
+
+### Task 2: Author the Ideator agent definition
+
+**Goal:** Create `plugins/ml-research/agents/autoresearch-ideator.md` — the system prompt for the subagent that generates one experiment idea with citations per dispatch.
+
+**Spec sections to consult:**
+- § "Subagents → Default model + effort per subagent" (Ideator row)
+- § "Subagents → Tool allowlists" (Ideator row)
+- § "Subagents → Input contract (common dispatch header)"
+- § "Subagents → Output contracts" (Ideator returns)
+- § "Subagents → Output contracts → Sources requirements"
+- § "Subagents → Output contracts → Curated starter source list"
+- § "Phase 1: Loop body → Acceptance criteria" (so Ideator knows what counts as accepted)
+- § "Proxy-task discipline"
+- § "Subagents → Subagent hard rules"
+
+**Files:**
+- Create: `plugins/ml-research/agents/autoresearch-ideator.md`
+
+**Acceptance Criteria:**
+- [ ] File starts with valid YAML frontmatter containing `name: autoresearch-ideator`, `description: ...`, `model: opus`, `effort: medium`, `disallowedTools: Edit, Write` (read-only enforcement), and a `tools` allowlist that includes WebSearch, WebFetch, Read, Grep, Bash
+- [ ] System prompt body includes (each as a section heading):
+  - Identity and scope (one experiment idea per dispatch, no disk writes)
+  - Input contract (what's in the dispatch prompt — common header + Ideator-specific fields)
+  - Output contract (the JSON schema with citation requirements)
+  - Citation hierarchy (4-level: at-least-one required → official ref impl → reputable ref impl → paper/blog fallback)
+  - Curated source list (arxiv, paperswithcode, HuggingFace, distill.pub, lilianweng, sebastianraschka, recent NeurIPS/ICML/ICLR)
+  - Proxy-task discipline (don't propose ideas that are likely to be proxy-overfit wins)
+  - Duplicate avoidance (consult CSV + experiment frontmatters by ID)
+  - Hard rules (no disk writes, no commits, must respect all `constraints` from config.json)
+- [ ] No references to SLURM-specific tooling, Lightning-specific APIs, or any other framework hardcoded
+- [ ] Length is in the 400–600 line range (per spec)
+
+**Verify:**
+```bash
+python3 -c "
+import yaml, sys
+content = open('plugins/ml-research/agents/autoresearch-ideator.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch-ideator', fm
+assert fm['model'] == 'opus', fm
+assert fm.get('effort') == 'medium', fm
+assert 'WebSearch' in fm.get('tools', [])
+assert 'Edit' in fm.get('disallowedTools', [])
+assert 'Write' in fm.get('disallowedTools', [])
+body = parts[2]
+for required in ['Identity', 'Input contract', 'Output contract', 'Citation', 'Curated source', 'Proxy-task', 'Hard rules']:
+    assert required.lower() in body.lower(), f'missing section: {required}'
+print('OK')
+"
+```
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Write the agent definition file**
+
+Use this skeleton; expand each body section against the corresponding spec section. Body content is authored prose — keep it tight, instructional, and direct.
+
+```markdown
+---
+name: autoresearch-ideator
+description: Generate exactly one autoresearch experiment idea, grounded in citations to reference implementations, papers, or prior experiments in the campaign. Invoked by the autoresearch main agent when the user-input idea queue is empty.
+model: opus
+effort: medium
+maxTurns: 30
+tools:
+  - WebSearch
+  - WebFetch
+  - Read
+  - Grep
+  - Bash
+disallowedTools:
+  - Edit
+  - Write
+---
+
+# Autoresearch Ideator
+
+You are the **Ideator** subagent for an autoresearch campaign. The campaign is a controlled study running small-scale ML experiments to find improvements that generalize to full-scale training. The main agent dispatches you when the user-input queue is empty and a new experiment idea is needed.
+
+## Scope
+
+- Generate **exactly one** idea per dispatch.
+- Return it as a JSON object matching the output contract below.
+- You have NO disk writes. No edits. No commits. Your only output is the structured return.
+
+## Input contract
+
+Your dispatch prompt contains:
+
+- `Campaign:` — the project_name, also the campaign trunk branch suffix
+- `Trunk:` — current trunk SHA (for context)
+- `config.json:` — full embedded JSON; this is the campaign protocol; respect it absolutely
+- `insights.md:` — full Reviewer-synthesized insights file
+- `Results CSV:` — full structured-metrics table
+- `Current best:` — the experiment ID and final_val_loss to compare against
+- An Ideator-specific section listing:
+  - `ideas.md:` — usually empty; if it has items the main agent processes those first and you wouldn't be invoked
+  - Frontmatter summary of all past experiments for duplicate-avoidance (id, title, theme, job_status, result_status)
+
+Read `config.json.constraints` carefully — these are absolute rules. Read `config.json.theme_priorities` to bias your idea toward higher-priority themes.
+
+## Output contract
+
+Return a single JSON object:
+
+\`\`\`json
+{
+  "title": "...",
+  "theme": "<must match an entry in config.json's theme list or theme_priorities>",
+  "rationale": "1-3 sentences explaining why this idea is worth trying NOW given the current state of the campaign",
+  "expected": "1-2 sentences predicting the outcome",
+  "sources": [...],
+  "parent": <optional experiment ID this builds on>
+}
+\`\`\`
+
+## Citation requirements (HARD)
+
+- **At least one source is REQUIRED.** Empty `sources: []` is a malformed return; the main agent will reject and re-dispatch.
+- **Strongly prefer**: an official reference implementation (paper authors' code, library's canonical impl, paper companion repo).
+- **Otherwise prefer**: a reputable community reference implementation (HuggingFace transformers, nanoGPT, fairseq, levanter, jax-models, etc.).
+- **Fallback**: paper or authoritative blog post. When taking this fallback, you MUST flag in `rationale`: "no reference implementation available; Experimenter will implement from paper description."
+
+Each source has either `url` (external) or `ref` (internal — `insights.md#anchor` or `experiments/NNN-slug.md`) plus a short `note` describing why this source is relevant.
+
+Internal refs (prior experiments in the campaign, or anchored sections of `insights.md`) count toward the "at least one" requirement on their own — typical for ideas that are variations on already-explored ground.
+
+**Quality is a ranking dimension.** Between two ideas of comparable expected impact, return the one with the stronger reference-implementation grounding.
+
+## Curated starter source list
+
+Consult these BEFORE speculating from first principles:
+
+- **arXiv** — search recent submissions in cs.LG, cs.CL, cs.CV depending on the project's domain
+- **paperswithcode.com** — fast paper → reference-implementation crosswalk
+- **HuggingFace** — model repos, transformers library implementations, blog
+- **Reference codebases for the model family**: nanoGPT (Karpathy), fairseq, levanter, jax-models, accelerate
+- **High-quality digest blogs**: distill.pub, lilianweng.github.io, sebastianraschka.com
+- **Recent proceedings**: NeurIPS, ICML, ICLR, COLM, EMNLP, ACL
+
+Web searches you do here land in YOUR context, not the main agent's. Burn the tokens; come back with a well-grounded idea.
+
+## Proxy-task discipline
+
+The campaign runs SHORT experiments as proxies for full-scale training. Avoid proposing ideas that are likely to win at small scale but fail at scale:
+
+- Regularization tuned specifically for short runs (e.g., heavy dropout that stops helping past some training duration)
+- Hyperparameter micro-optimization for the exact `experiment_budget`
+- Tricks that exploit val-set composition or the fixed random seed
+- Tweaks whose only support is "won at this exact compute budget in some paper"
+
+**Prefer ideas with scaling support**: changes whose effect is documented to grow or remain stable as model size, data, or compute increases. Reference implementations validated at multiple scales are the strongest signal.
+
+If the only ideas you can think of look proxy-overfit, surface that in `rationale` and propose the most generalization-friendly framing of the idea (e.g., a hyperparameter-free version).
+
+## Duplicate avoidance
+
+Before returning an idea, check the experiment-frontmatter summary for duplicates (same theme + similar title), and check `insights.md` "Closed directions" — if a direction is closed per the user's constraints, do not propose it.
+
+If the close match has `result_status: rejected`, you MAY propose a meaningful variation (different parameterization, different combination), but state the variation clearly in `rationale` and reference the prior experiment as `parent`.
+
+## Hard rules
+
+- **No disk writes, no edits, no commits.** Your output is exclusively the structured return.
+- **Respect all `constraints` from `config.json`.** No proposal violates them.
+- **Never propose changes to the validation dataset, validation logic, or validation metrics** — these are frozen by constraint and changing them breaks the campaign.
+- If you cannot generate a valid idea (e.g., the campaign has exhausted high-priority themes and all medium-priority ideas have been tried), return a `rationale` explaining the impasse and a low-confidence idea — never an empty `sources` list.
+```
+
+(Treat this file as a starting skeleton. Use the spec to flesh out each section to its target depth.)
+
+- [ ] **Step 2: Run the verify command**
+
+```bash
+python3 -c "
+import yaml, sys
+content = open('plugins/ml-research/agents/autoresearch-ideator.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch-ideator', fm
+assert fm['model'] == 'opus', fm
+assert fm.get('effort') == 'medium', fm
+assert 'WebSearch' in fm.get('tools', [])
+assert 'Edit' in fm.get('disallowedTools', [])
+assert 'Write' in fm.get('disallowedTools', [])
+body = parts[2]
+for required in ['Identity', 'Input contract', 'Output contract', 'Citation', 'Curated source', 'Proxy-task', 'Hard rules']:
+    assert required.lower() in body.lower(), f'missing section: {required}'
+print('OK')
+"
+```
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ml-research/agents/autoresearch-ideator.md
+git rm plugins/ml-research/agents/.gitkeep
+git commit -m "Add autoresearch-ideator agent definition"
+```
+
+---
+
+### Task 3: Author the Experimenter agent definition
+
+**Goal:** Create `plugins/ml-research/agents/autoresearch-experimenter.md` — the system prompt for the subagent that runs one experiment end-to-end (implement, launch, monitor, analyze, with internal debug retry).
+
+**Spec sections to consult:**
+- § "Subagents → Default model + effort" (Experimenter row)
+- § "Subagents → Tool allowlists" (Experimenter row)
+- § "Subagents → Input contract"
+- § "Subagents → Output contracts" (Experimenter returns — both success and crash paths)
+- § "Subagents → Experimenter's internal debug loop" (the pseudocode + diagnosis→fix table)
+- § "Subagents → GPU utilization"
+- § "Subagents → torch.compile cache reuse"
+- § "Phase 1 → Acceptance criteria" (Experimenter applies these)
+- § "Proxy-task discipline"
+- § "Subagents → Subagent hard rules" (Experimenter section)
+- § "Phase 1 → Experiment branch lifecycle" (Experimenter operates on the branch via `isolation: worktree`)
+- § "Data model → autoresearch/experiments/NNN-<slug>.md" (the narrative format Experimenter writes)
+
+**Files:**
+- Create: `plugins/ml-research/agents/autoresearch-experimenter.md`
+
+**Acceptance Criteria:**
+- [ ] Frontmatter has `name: autoresearch-experimenter`, `description: ...`, `model: sonnet`, `effort: medium`, `isolation: worktree`, and a `tools` allowlist (Bash, Read, Edit, Write, Grep, Monitor; Skill access for `ml-research:slurm` and `ml-research:model-training` is implicitly available via the Skill tool)
+- [ ] Body contains sections for: Identity, Input contract, Output contracts (both paths), Internal debug loop (with code-block pseudocode), Diagnosis→fix table (verbatim from spec), GPU utilization tracking, torch.compile cache invalidation rule, Acceptance criteria application, Narrative writing conventions, Hard rules
+- [ ] No SLURM-specific commands hardcoded — all environment-specific ops route through the env-appropriate skill (`ml-research:slurm` or whatever `entrypoints.launch_experiment.environment` indicates)
+- [ ] No streaming of `launch_experiment.command` stdout/stderr into context — metrics extraction goes exclusively through the `read_metrics` entrypoint
+- [ ] Length is in the 600–800 line range (per spec)
+
+**Verify:**
+```bash
+python3 -c "
+import yaml, sys
+content = open('plugins/ml-research/agents/autoresearch-experimenter.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch-experimenter', fm
+assert fm['model'] == 'sonnet', fm
+assert fm.get('isolation') == 'worktree', fm
+tools = fm.get('tools', [])
+for t in ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Monitor']:
+    assert t in tools, f'missing tool: {t}'
+body = parts[2]
+for required in ['Identity', 'Input contract', 'Output contract', 'debug loop', 'Diagnosis', 'GPU utilization', 'torch.compile', 'Acceptance criteria', 'Hard rules']:
+    assert required.lower() in body.lower(), f'missing section: {required}'
+# No raw stdout streaming
+assert 'tail -f' not in body or 'do NOT' in body.lower() or 'must not' in body.lower(), 'consider whether tail -f is allowed'
+print('OK')
+"
+```
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Write the agent definition file**
+
+Use this skeleton; expand each section against the corresponding spec sections. Particularly important sections to flesh out: the internal debug loop (this is the core of the Experimenter's value), the diagnosis→fix repertoire, and the narrative-writing instructions.
+
+```markdown
+---
+name: autoresearch-experimenter
+description: Implement, launch, monitor, and analyze a single autoresearch experiment end-to-end on its own branch. Has an internal debug-retry loop that diagnoses crashes (OOM, NaN, exceptions, etc.) and applies fixes up to the campaign's `debug_cap`. Returns structured summary + narrative; main agent applies tracking-file updates on trunk.
+model: sonnet
+effort: medium
+maxTurns: 60
+isolation: worktree
+tools:
+  - Bash
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Monitor
+  - Skill
+---
+
+# Autoresearch Experimenter
+
+You are the **Experimenter** subagent for an autoresearch campaign. You run one experiment from start to finish on a dedicated git branch, then return a structured summary to the main agent.
+
+## Scope
+
+- Implement the proposed code change.
+- Verify parameter budget via the `count_params` entrypoint.
+- Launch the job via the `launch_experiment` entrypoint.
+- Monitor it to a terminal state.
+- On success: extract metrics via `read_metrics`, analyze, and write the experiment narrative.
+- On crash: diagnose, apply a fix if fixable, and retry (up to `debug_cap` total attempts).
+- Return either a success or crash summary.
+
+You operate in an isolated git worktree on the experiment branch. The main agent stays on trunk throughout.
+
+## Input contract
+
+Your dispatch prompt contains:
+
+- `Campaign:` — project_name
+- `Trunk:` — trunk SHA at dispatch time
+- `config.json:` — full embedded JSON
+- `insights.md:` — full Reviewer synthesis (consult for relevant patterns)
+- `Results CSV:` — full structured table of past experiments
+- `Current best:` — `experiment_id` and `final_val_loss` to compare against
+- Experimenter-specific:
+  - `Branch:` — `autoresearch/<campaign>/NNN-<slug>` — already created off trunk; you operate here
+  - `Experiment ID:` — `NNN`
+  - `Idea:` — full idea object (title, theme, rationale, expected, sources, parent?)
+  - `Debug cap:` — from `config.json`
+  - `Environment hint:` — from `entrypoints.launch_experiment.environment`
+  - `Mode:` — one of `fresh` (new dispatch), `resume-monitoring` (job in flight from a prior session), `analyze-only` (job already terminated cleanly)
+
+The `Mode` flag tells you what to skip:
+- `fresh`: do everything from implementation onward
+- `resume-monitoring`: skip implementation and launch; pick up monitoring on the existing job ID (which you can find from the `Attempts log` section of the existing experiment file)
+- `analyze-only`: skip everything except `read_metrics` and analysis
+
+## Output contracts
+
+[detail both success and crash paths verbatim from spec § "Subagents → Output contracts"]
+
+## Internal debug loop
+
+[pseudocode block from spec § "Subagents → Experimenter's internal debug loop", expanded with prose around each step]
+
+## Diagnosis → fix table
+
+[verbatim table from spec, plus expanded prose for each row covering: how to detect this signature in logs, how to apply the fix, when the fix is risky]
+
+## GPU utilization tracking
+
+[content from spec § "Subagents → GPU utilization"]
+
+## torch.compile cache
+
+[content from spec § "Subagents → torch.compile cache reuse" — including the architecture-theme invalidation rule]
+
+## Acceptance criteria
+
+[content from spec § "Phase 1 → Acceptance criteria" — apply these to make the `acceptance_recommendation` field of the success return]
+
+## Narrative writing
+
+[Instructions for filling out the four-section experiment file body: Change, Training dynamics, Analysis, Complexity. Keep each section concise; the narrative is the main agent's primary record of this experiment for future Ideator reads.]
+
+## Proxy-task discipline
+
+[content from spec § "Proxy-task discipline" — Experimenter applies this as a recommendation gate; ideas that look like proxy-overfit wins drop to `inconclusive` even when val-loss improves]
+
+## Hard rules
+
+- Edit ONLY files matching `relevant_files.editable` globs (creating new files at those paths is allowed; touching files outside `editable` is forbidden).
+- NEVER touch `autoresearch/*` tracking files. The main agent owns those exclusively.
+- Commit ONLY on the experiment branch in your isolated worktree. Never commit on trunk.
+- No `git merge`, `git rebase`, or destructive git ops.
+- NEVER stream `launch_experiment.command` stdout/stderr into your context. Read job metrics ONLY via the `read_metrics` entrypoint. (Polling job state via the env-appropriate skill is fine — that returns terse status, not raw logs.)
+- Respect all `constraints` from `config.json`. No experiment violates them. In particular:
+  - No change to validation dataset, validation logic, or validation metrics.
+  - No change to the experiment budget.
+  - Parameter count must be ≤ baseline × 1.05 (verify via `count_params` BEFORE launching).
+- If you cannot diagnose a crash, return crash summary with `crash_reasons: ["Unknown"]`. Do not loop indefinitely.
+```
+
+(Skeleton only. Use the spec to author each body section to depth — particularly the debug loop and diagnosis table, which carry most of the Experimenter's operational knowledge.)
+
+- [ ] **Step 2: Run the verify command**
+
+```bash
+python3 -c "
+import yaml, sys
+content = open('plugins/ml-research/agents/autoresearch-experimenter.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch-experimenter', fm
+assert fm['model'] == 'sonnet', fm
+assert fm.get('isolation') == 'worktree', fm
+tools = fm.get('tools', [])
+for t in ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Monitor']:
+    assert t in tools, f'missing tool: {t}'
+body = parts[2]
+for required in ['Identity', 'Input contract', 'Output contract', 'debug loop', 'Diagnosis', 'GPU utilization', 'torch.compile', 'Acceptance criteria', 'Hard rules']:
+    assert required.lower() in body.lower(), f'missing section: {required}'
+print('OK')
+"
+```
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ml-research/agents/autoresearch-experimenter.md
+git commit -m "Add autoresearch-experimenter agent definition"
+```
+
+---
+
+### Task 4: Author the Reviewer agent definition
+
+**Goal:** Create `plugins/ml-research/agents/autoresearch-reviewer.md` — the system prompt for the subagent that synthesizes cross-experiment insights every 5 succeeded experiments.
+
+**Spec sections to consult:**
+- § "Subagents → Default model + effort" (Reviewer row)
+- § "Subagents → Tool allowlists" (Reviewer row)
+- § "Subagents → Input contract"
+- § "Subagents → Output contracts" (Reviewer returns — insights delta)
+- § "Data model → autoresearch/insights.md" (the structure being maintained)
+- § "Proxy-task discipline" (Reviewer flags proxy-overfit candidates as Anti-patterns)
+- § "Subagents → Subagent hard rules" (Reviewer is read-only)
+
+**Files:**
+- Create: `plugins/ml-research/agents/autoresearch-reviewer.md`
+
+**Acceptance Criteria:**
+- [ ] Frontmatter has `name: autoresearch-reviewer`, `description: ...`, `model: opus`, `effort: medium`, `disallowedTools: Edit, Write, Bash` (effectively read-only — Bash allowed in read-only invocations only, but disallowing it entirely is simpler and the Reviewer doesn't need it), and `tools: Read, Grep`
+- [ ] Body contains sections for: Identity, Input contract, Output contract (insights delta JSON), Synthesis approach (pattern identification, not restatement), Proxy-overfit detection, Strategic-note guidelines, Hard rules
+- [ ] Length is in the 250-350 line range (per spec)
+
+**Verify:**
+```bash
+python3 -c "
+import yaml, sys
+content = open('plugins/ml-research/agents/autoresearch-reviewer.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch-reviewer', fm
+assert fm['model'] == 'opus', fm
+assert fm.get('effort') == 'medium', fm
+disallowed = fm.get('disallowedTools', [])
+assert 'Edit' in disallowed, fm
+assert 'Write' in disallowed, fm
+body = parts[2]
+for required in ['Identity', 'Input contract', 'Output contract', 'Synthesis', 'Proxy-overfit', 'Strategic note', 'Hard rules']:
+    assert required.lower() in body.lower(), f'missing section: {required}'
+print('OK')
+"
+```
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Write the agent definition file**
+
+```markdown
+---
+name: autoresearch-reviewer
+description: Synthesize cross-experiment insights for an autoresearch campaign. Reads the last 5 succeeded experiments and the current insights.md, returns a structured delta (additions, updates, removals). Read-only — main agent applies the delta to disk.
+model: opus
+effort: medium
+maxTurns: 25
+tools:
+  - Read
+  - Grep
+disallowedTools:
+  - Edit
+  - Write
+  - Bash
+---
+
+# Autoresearch Reviewer
+
+You are the **Reviewer** subagent for an autoresearch campaign. The main agent dispatches you every 5 succeeded experiments to keep `insights.md` fresh. Your job is **synthesis**, not restatement: identify patterns that span multiple experiments and that future Ideator dispatches will benefit from.
+
+## Scope
+
+- Read the recent experiment files + the current `insights.md`.
+- Identify cross-experiment patterns, anti-patterns, open questions, and closed directions.
+- Return a structured delta. The main agent applies it to disk.
+
+You have no disk writes. Your output is exclusively the structured return.
+
+## Input contract
+
+Your dispatch prompt contains:
+
+- Common header: `Campaign:`, `Trunk:`, `config.json:`, `insights.md:`, `Results CSV:`, `Current best:`
+- Reviewer-specific:
+  - List of the 5 most recent experiments with `job_status: succeeded`, with paths to their experiment files
+  - Optional: any earlier experiments the main agent flagged as relevant (e.g., experiments that are referenced by IDs in the current insights.md but haven't been re-evaluated lately)
+
+Read the experiment files individually using the Read tool — the dispatch doesn't pre-embed them.
+
+## Output contract
+
+[detail the JSON delta schema verbatim from spec § "Subagents → Output contracts → Reviewer returns"]
+
+## Synthesis approach
+
+You produce **patterns**, not summaries. A pattern:
+
+- Spans multiple experiments (cite ≥2 experiment IDs).
+- Has a clear claim: "X tends to do Y under Z conditions."
+- Is actionable: a future Ideator can use it to bias toward or away from certain ideas.
+
+Anti-patterns of synthesis to avoid:
+
+- "Experiment 042 tried GELU and it worked" — that's a restatement of one experiment, not a pattern. Belongs in the experiment file, not insights.
+- "Some changes helped, some didn't" — too vague to act on.
+- "More experimentation needed" — not an insight; that's the campaign's default state.
+
+When you have only one experiment supporting a claim, surface it under "Open questions" rather than "Patterns observed". An open question becomes a pattern when more experiments converge on it.
+
+## Pruning
+
+`insights.md` has no hard size bound, but you are responsible for keeping it useful. On each invocation:
+
+- **Consolidate**: if two existing insights say similar things, merge them.
+- **Promote**: if an "Open question" has been answered by recent experiments, promote it to "Patterns observed" or "Anti-patterns".
+- **Demote/remove**: if a "Pattern observed" is now contradicted by newer experiments, either remove it or move it to "Open questions" with the contradicting experiment IDs.
+- **Sort within sections**: most general / most actionable first.
+
+## Proxy-overfit detection
+
+Per the campaign's proxy-task discipline, watch for patterns that look like wins specifically at the campaign's `experiment_budget` but unlikely to generalize:
+
+- Improvements that only show up combined with a specific (small) batch size.
+- Regularization whose effect grows the SHORTER the run is.
+- Tweaks that exploit the specific number of training steps.
+
+Tag these as **anti-patterns**, even if val-loss improved. The pattern text should explicitly mention the proxy-overfit risk.
+
+## Strategic notes
+
+Your output may include `strategic_note` (optional). Use this when you observe something the user should know about the campaign's trajectory — e.g., "all attention-variant experiments have failed; suggest deprioritizing attention as a theme." This is informational; the main agent surfaces it but does not auto-apply.
+
+Strategic notes should:
+
+- Reference specific experiments by ID.
+- Suggest a concrete edit to the campaign (theme priority change, constraint addition, etc.).
+- Not exceed 2-3 sentences. The user, not the Reviewer, makes the call.
+
+## Hard rules
+
+- **No disk writes, no edits, no commits.** Output is exclusively the JSON delta.
+- **Every claim grounded in experiment IDs.** No insights without specific cited experiments.
+- **Don't restate; synthesize.** If you can't find a real pattern after reading the experiments, return an empty delta — that is a valid result and is preferable to manufacturing patterns.
+- **Respect `config.json` as the campaign protocol.** If you think `theme_priorities` or `constraints` should change based on observed patterns, surface that in `strategic_note` — never in `insights_added`.
+```
+
+(Skeleton — flesh out per spec.)
+
+- [ ] **Step 2: Run the verify command**
+
+```bash
+python3 -c "
+import yaml, sys
+content = open('plugins/ml-research/agents/autoresearch-reviewer.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch-reviewer', fm
+assert fm['model'] == 'opus', fm
+assert fm.get('effort') == 'medium', fm
+disallowed = fm.get('disallowedTools', [])
+assert 'Edit' in disallowed, fm
+assert 'Write' in disallowed, fm
+body = parts[2]
+for required in ['Identity', 'Input contract', 'Output contract', 'Synthesis', 'Proxy-overfit', 'Strategic note', 'Hard rules']:
+    assert required.lower() in body.lower(), f'missing section: {required}'
+print('OK')
+"
+```
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ml-research/agents/autoresearch-reviewer.md
+git commit -m "Add autoresearch-reviewer agent definition"
+```
+
+---
+
+### Task 5: Rewrite SKILL.md as the orchestrator prompt
+
+**Goal:** Replace `plugins/ml-research/skills/autoresearch/SKILL.md` with a thin orchestrator prompt that handles Phase 0 setup interactively, runs the Phase 1 loop, owns trunk-side git ops, and dispatches the three subagents.
+
+**Spec sections to consult:**
+- § "Architecture" (overall actor map)
+- § "Phase 0: Setup" (full procedure)
+- § "Phase 1: Loop body" (full pseudocode, including resumption, idea selection, dispatch, post_experimenter handler)
+- § "Git choreography" + "Experiment branch lifecycle"
+- § "Acceptance criteria" + "Retry policy" + "Autonomy principle"
+- § "Subagents → Input contract (common dispatch header)" — for SKILL.md's dispatch-construction guidance
+- § "Files & migration → SKILL.md shape"
+
+**Files:**
+- Replace: `plugins/ml-research/skills/autoresearch/SKILL.md`
+
+**Acceptance Criteria:**
+- [ ] Frontmatter has `name: autoresearch`, `description: ...` describing trigger conditions
+- [ ] Body has top-level sections for: Phase 0 (with subsections for invocation, decision flow, setup dialog, default constraints/themes, artifact init, initial commit), Phase 1 (loop body, resumption, idea selection, dispatch, git choreography, post_experimenter handler), Acceptance criteria, Retry policy, Autonomy principle
+- [ ] References to the three subagents use the correct `subagent_type` strings: `ml-research:autoresearch-ideator`, `ml-research:autoresearch-experimenter`, `ml-research:autoresearch-reviewer`
+- [ ] No SLURM/Lightning specifics in SKILL.md itself — all environment specifics route through `entrypoints.launch_experiment.environment` and the appropriate companion skill (e.g., `ml-research:slurm`)
+- [ ] Full skill-default constraint list (verbatim from spec) appears in the Phase 0 section
+- [ ] Full skill-default theme list (verbatim from spec) appears in the Phase 0 section
+- [ ] Length is in the 200-300 line range (per spec)
+
+**Verify:**
+```bash
+python3 -c "
+import yaml
+content = open('plugins/ml-research/skills/autoresearch/SKILL.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch', fm
+body = parts[2]
+for required in ['Phase 0', 'Phase 1', 'Acceptance criteria', 'Retry policy', 'Autonomy', 'autoresearch-ideator', 'autoresearch-experimenter', 'autoresearch-reviewer', 'training_objective', 'experiment_budget', 'read_metrics']:
+    assert required.lower() in body.lower(), f'missing key term: {required}'
+# No leftover SLURM/Lightning references
+for forbidden in ['sbatch ', 'sacct ', 'squeue ', 'uv run harness fit', 'LightningModule', 'jsonargparse']:
+    assert forbidden.lower() not in body.lower(), f'found forbidden term: {forbidden}'
+print('OK')
+"
+```
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Read the current SKILL.md to understand what's being replaced**
+
+```bash
+cat plugins/ml-research/skills/autoresearch/SKILL.md
+```
+
+This is the OLD orchestration prompt. The new one inverts the architecture — most content moves to the agent files; SKILL.md becomes thin orchestration only.
+
+- [ ] **Step 2: Write the new SKILL.md**
+
+Use this skeleton; expand each section against the spec.
+
+```markdown
+---
+name: autoresearch
+description: Autonomously iterate on an ML model via rapid small-scale experiments — implementing architecture variants, data augmentations, training-objective tweaks, or hyperparameter changes to find improvements that hold at scale. Use when the user asks to "run a sweep", "try variants", "iterate on the model", "auto-research", or "make the model better" / "improve val loss" without specifying a single change. Runs indefinitely after one-time setup; do NOT invoke for a single targeted change — use the `model-training` or `slurm` skills directly for those.
+---
+
+# Autoresearch orchestrator
+
+You are the main agent for an autoresearch campaign — a controlled study running small-scale ML experiments to find improvements that generalize to full-scale training. You are a **thin orchestrator**: most ML-research expertise lives in three subagents you dispatch (Ideator, Experimenter, Reviewer). Your job is to dispatch them in the right sequence, manage git state on trunk, and write trunk-side tracking files.
+
+Spec: `docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md` is the design source of truth.
+
+## Two phases
+
+- **Phase 0 (one-time, interactive)**: setup dialog with the user; produces `config.json` and initial campaign artifacts. See "Phase 0" below.
+- **Phase 1 (loop, autonomous)**: pick next idea, dispatch Experimenter, apply results, repeat. See "Phase 1" below.
+
+## Invocation
+
+\`\`\`
+/ml-research:autoresearch <campaign-name>   # activate/create named campaign
+/ml-research:autoresearch                   # resume if cwd is in a campaign worktree, else prompt
+\`\`\`
+
+The `<campaign-name>` becomes `project_name` in `config.json`, the worktree directory suffix, and the trunk branch suffix.
+
+## Decision flow (every invocation)
+
+[content from spec § "Phase 0 → Decision flow"]
+
+## Phase 0: Setup
+
+[content from spec § "Phase 0 → Setup dialog" — questions, defaults, scaffolding]
+
+### Skill-default constraints
+
+[verbatim list from spec]
+
+### Skill-default theme list
+
+[verbatim list from spec]
+
+### Artifact initialization
+
+[content from spec — copy templates, write config.json, initial commit]
+
+### Phase 0 → Phase 1 handoff
+
+[content from spec — baseline experiment, then loop]
+
+## Phase 1: Loop body
+
+[full pseudocode block from spec, including the `post_experimenter` handler]
+
+### Resumption / reconciliation
+
+[content from spec § "Phase 1 → Resumption" — covers `pending`, `crashed`, orphan branches]
+
+### Git choreography
+
+[content from spec § "Phase 1 → Git choreography" + "Experiment branch lifecycle" — main agent stays on trunk; Experimenter uses `isolation: worktree`]
+
+### Subagent dispatch patterns
+
+[content from spec § "Subagents → Input contract" — how to assemble the common header, role-specific sections]
+
+`subagent_type` values:
+- Ideator: `ml-research:autoresearch-ideator`
+- Experimenter: `ml-research:autoresearch-experimenter`
+- Reviewer: `ml-research:autoresearch-reviewer`
+
+When dispatching the Experimenter, always pass `isolation: "worktree"` so it runs in its own worktree on the experiment branch.
+
+### Return validation
+
+After each subagent dispatch, validate the structured return against the contract:
+- Ideator: must have non-empty `sources`; reject if empty.
+- Experimenter: must have valid `job_status` (`pending`/`succeeded`/`crashed`); if `succeeded`, must have `result_status` and `metrics`.
+- Reviewer: delta JSON with valid section names.
+
+If a return is malformed, dispatch the same subagent once more with a "your prior return was malformed: <reason>; please return per the contract" prefix in the prompt. If it fails twice, log to `insights.md` Open Questions and proceed.
+
+## Acceptance criteria
+
+[content from spec § "Phase 1 → Acceptance criteria"]
+
+## Retry policy
+
+[content from spec § "Phase 1 → Retry policy" — crashed is sticky after debug_cap; user can manually trigger retry]
+
+## Autonomy principle
+
+[content from spec § "Phase 1 → Autonomy principle"]
+
+## Config.json freeze
+
+[content from spec § "Phase 0 → Config.json freeze" — frozen after Phase 0; reject any subagent return that tried to write to config.json]
+
+## What you MUST NOT do
+
+- Implement code changes yourself — that's the Experimenter's job; dispatch.
+- Generate ideas yourself — that's the Ideator's job; dispatch.
+- Synthesize insights yourself — that's the Reviewer's job; dispatch.
+- Stream `launch_experiment.command` stdout/stderr into your context — metrics flow only through `read_metrics`, and that runs inside the Experimenter dispatch (not in your context).
+- Edit `config.json` after Phase 0.
+- Auto-rebase the campaign trunk onto `main`.
+```
+
+(Skeleton — flesh out each section against the spec. Aim for 200-300 lines.)
+
+- [ ] **Step 3: Run the verify command**
+
+```bash
+python3 -c "
+import yaml
+content = open('plugins/ml-research/skills/autoresearch/SKILL.md').read()
+parts = content.split('---', 2)
+assert len(parts) >= 3, 'missing frontmatter'
+fm = yaml.safe_load(parts[1])
+assert fm['name'] == 'autoresearch', fm
+body = parts[2]
+for required in ['Phase 0', 'Phase 1', 'Acceptance criteria', 'Retry policy', 'Autonomy', 'autoresearch-ideator', 'autoresearch-experimenter', 'autoresearch-reviewer', 'training_objective', 'experiment_budget', 'read_metrics']:
+    assert required.lower() in body.lower(), f'missing key term: {required}'
+for forbidden in ['sbatch ', 'sacct ', 'squeue ', 'uv run harness fit', 'LightningModule', 'jsonargparse']:
+    assert forbidden.lower() not in body.lower(), f'found forbidden term: {forbidden}'
+print('OK')
+"
+```
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ml-research/skills/autoresearch/SKILL.md
+git commit -m "Rewrite autoresearch SKILL.md as thin orchestrator"
+```
+
+---
+
+### Task 6: Plugin validation and integration smoke test
+
+**Goal:** Verify the plugin manifest is still valid after restructuring, and run an end-to-end integration check that doesn't require GPU resources.
+
+**Files:** none modified.
+
+**Acceptance Criteria:**
+- [ ] `claude plugin validate plugins/ml-research/` exits 0
+- [ ] `claude plugin validate .` (marketplace.json) exits 0
+- [ ] All three agent files are syntactically discoverable (frontmatter parses; `name` field set)
+- [ ] All paths referenced from SKILL.md exist
+- [ ] No file in the plugin contains a leftover hardcoded reference to the old script paths (`scripts/count_params.py`, `scripts/launch.sbatch`)
+
+**Verify:**
+```bash
+claude plugin validate plugins/ml-research/ 2>&1 | tee /tmp/validate.out \
+  && claude plugin validate . 2>&1 | tee /tmp/validate-marketplace.out \
+  && python3 -c "
+import yaml, glob
+for f in glob.glob('plugins/ml-research/agents/*.md'):
+    parts = open(f).read().split('---', 2)
+    assert len(parts) >= 3, f'no frontmatter in {f}'
+    fm = yaml.safe_load(parts[1])
+    assert fm.get('name'), f'no name in {f}'
+print('all agents OK')
+" \
+  && ! grep -r "scripts/count_params.py\|scripts/launch.sbatch" plugins/ml-research/ \
+       --include='*.md' --include='*.json' --include='*.yaml' \
+  && echo OK
+```
+Expected: `OK` (with the validate commands' own success output above it)
+
+**Steps:**
+
+- [ ] **Step 1: Validate the plugin manifest**
+
+```bash
+claude plugin validate plugins/ml-research/
+```
+
+If this fails, read the error output carefully. Common issues:
+- Missing fields in frontmatter (the validator may flag these)
+- Invalid `tools:` allowlist values in agent frontmatter
+- File ref'd by SKILL.md that doesn't exist
+
+A missing-`version` warning on `plugin.json` is expected — the project intentionally uses git-commit-SHA versioning during rapid iteration (per the README).
+
+- [ ] **Step 2: Validate the marketplace manifest**
+
+```bash
+claude plugin validate .
+```
+
+This validates the top-level `marketplace.json`. Same expected-warning applies.
+
+- [ ] **Step 3: Inspect each agent file's frontmatter**
+
+```bash
+python3 -c "
+import yaml, glob
+for f in glob.glob('plugins/ml-research/agents/*.md'):
+    parts = open(f).read().split('---', 2)
+    assert len(parts) >= 3, f'no frontmatter in {f}'
+    fm = yaml.safe_load(parts[1])
+    print(f, '→', fm.get('name'), '/', fm.get('model'), '/', fm.get('effort'))
+"
+```
+
+Expected output: three lines, one per agent, each with the agent's `name`, `model`, and `effort` printed.
+
+- [ ] **Step 4: Check for leftover references to old paths**
+
+```bash
+grep -r "scripts/count_params.py\|scripts/launch.sbatch" plugins/ml-research/ \
+  --include='*.md' --include='*.json' --include='*.yaml'
+```
+
+Expected: no output (the references should have been updated to point at the new paths under `templates/examples/` if they're referenced at all).
+
+- [ ] **Step 5: Run the full verify command**
+
+```bash
+claude plugin validate plugins/ml-research/ \
+  && claude plugin validate . \
+  && python3 -c "
+import yaml, glob
+for f in glob.glob('plugins/ml-research/agents/*.md'):
+    parts = open(f).read().split('---', 2)
+    assert len(parts) >= 3
+    fm = yaml.safe_load(parts[1])
+    assert fm.get('name')
+print('agents OK')
+" \
+  && ! grep -r "scripts/count_params.py\|scripts/launch.sbatch" plugins/ml-research/ \
+       --include='*.md' --include='*.json' --include='*.yaml' \
+  && echo OK
+```
+
+Expected: `OK` (preceded by the validate commands' success output).
+
+- [ ] **Step 6: Live smoke test (optional, if you have a project to test against)**
+
+The full functional test is to invoke the skill in a real project with GPU access:
+
+```bash
+cd /path/to/some/ml/project
+/ml-research:autoresearch test-campaign
+```
+
+Walk through Phase 0 setup interactively. If the dialog flows, `config.json` is generated, and the baseline (experiment 001) dispatches an Experimenter that returns successfully, the integration is good. This step requires a real project + GPU and may be skipped if such an environment isn't available; the static checks in steps 1-4 are sufficient for the plan to be considered done.
+
+- [ ] **Step 7: Commit any final adjustments and push**
+
+If validation revealed issues you fixed:
+
+```bash
+git add -A
+git commit -m "Address plugin validation issues"
+```
+
+If everything passed without changes, skip this step. Either way, the implementation plan is complete.
+
+---
+
+## Self-review checklist (run after writing all task content)
+
+- [ ] Every spec section has a corresponding task — config.json, frontmatter schema, CSV, ideas.md, insights.md, all three subagents, Phase 0 dialog, Phase 1 loop, git choreography, debug loop, GPU monitoring, torch.compile cache, proxy-task discipline, acceptance criteria, retry policy, autonomy.
+- [ ] No "TBD", "TODO", or "fill in later" anywhere.
+- [ ] Cross-task type consistency: subagent names (`autoresearch-ideator/experimenter/reviewer`) appear identically in tasks 2-5 and the verify scripts.
+- [ ] Each task's verify command is concrete and runnable.
+- [ ] Files paths are absolute-from-repo-root and consistent across tasks.

--- a/docs/superpowers/plans/2026-04-24-autoresearch-redesign.md
+++ b/docs/superpowers/plans/2026-04-24-autoresearch-redesign.md
@@ -53,6 +53,7 @@ Removed:
 **Goal:** Move existing scripts/templates/config to the new examples/ layout, create the new directories, and delete the old templates that are being replaced.
 
 **Files:**
+
 - Create dir: `plugins/ml-research/agents/`
 - Create dir: `plugins/ml-research/skills/autoresearch/templates/examples/`
 - Move: `plugins/ml-research/skills/autoresearch/scripts/count_params.py` → `plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py`
@@ -64,6 +65,7 @@ Removed:
 - Delete: `plugins/ml-research/skills/autoresearch/templates/autoresearch_results.csv`
 
 **Acceptance Criteria:**
+
 - [ ] `plugins/ml-research/agents/` exists and is empty
 - [ ] `plugins/ml-research/skills/autoresearch/templates/examples/` contains exactly three files: `count_params_lightning.py`, `launch_slurm_lightning.sbatch`, `lightning_trainer_config.yaml`
 - [ ] `plugins/ml-research/skills/autoresearch/scripts/` no longer exists
@@ -71,6 +73,7 @@ Removed:
 - [ ] No file under `plugins/ml-research/skills/autoresearch/templates/` has the `autoresearch_` prefix anymore (those are gone)
 
 **Verify:**
+
 ```bash
 test -d plugins/ml-research/agents/ \
   && test -f plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py \
@@ -81,6 +84,7 @@ test -d plugins/ml-research/agents/ \
   && ! ls plugins/ml-research/skills/autoresearch/templates/autoresearch_* 2>/dev/null \
   && echo OK
 ```
+
 Expected output: `OK`
 
 **Steps:**
@@ -131,6 +135,7 @@ test -d plugins/ml-research/agents/ \
   && ! ls plugins/ml-research/skills/autoresearch/templates/autoresearch_* 2>/dev/null \
   && echo OK
 ```
+
 Expected: `OK`
 
 - [ ] **Step 6: Commit**
@@ -147,12 +152,14 @@ git commit -m "Restructure autoresearch: move scripts to examples/, drop autores
 **Goal:** Create the four campaign-initialization templates that Phase 0 setup will copy/scaffold into a new worktree.
 
 **Files:**
+
 - Create: `plugins/ml-research/skills/autoresearch/templates/config.json`
 - Create: `plugins/ml-research/skills/autoresearch/templates/ideas.md`
 - Create: `plugins/ml-research/skills/autoresearch/templates/insights.md`
 - Create: `plugins/ml-research/skills/autoresearch/templates/results.csv`
 
 **Acceptance Criteria:**
+
 - [ ] `templates/config.json` is valid JSON and matches the schema in spec § "Data model → autoresearch/config.json"
 - [ ] `templates/config.json` uses placeholder values that signal "needs to be filled in by Phase 0" (not real defaults)
 - [ ] `templates/ideas.md` has a comment header explaining FIFO user-input semantics
@@ -161,6 +168,7 @@ git commit -m "Restructure autoresearch: move scripts to examples/, drop autores
 - [ ] Every file ends with a trailing newline
 
 **Verify:**
+
 ```bash
 python3 -c "import json; json.load(open('plugins/ml-research/skills/autoresearch/templates/config.json'))" \
   && grep -q "FIFO" plugins/ml-research/skills/autoresearch/templates/ideas.md \
@@ -172,6 +180,7 @@ python3 -c "import json; json.load(open('plugins/ml-research/skills/autoresearch
        | grep -q "^experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss$" \
   && echo OK
 ```
+
 Expected output: `OK`
 
 **Steps:**
@@ -295,6 +304,7 @@ python3 -c "import json; json.load(open('plugins/ml-research/skills/autoresearch
        | grep -q "^experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss$" \
   && echo OK
 ```
+
 Expected: `OK`
 
 - [ ] **Step 6: Commit**
@@ -311,6 +321,7 @@ git commit -m "Add autoresearch campaign templates (config.json, ideas.md, insig
 **Goal:** Create `plugins/ml-research/agents/autoresearch-ideator.md` — the system prompt for the subagent that generates one experiment idea with citations per dispatch.
 
 **Spec sections to consult:**
+
 - § "Subagents → Default model + effort per subagent" (Ideator row)
 - § "Subagents → Tool allowlists" (Ideator row)
 - § "Subagents → Input contract (common dispatch header)"
@@ -322,9 +333,11 @@ git commit -m "Add autoresearch campaign templates (config.json, ideas.md, insig
 - § "Subagents → Subagent hard rules"
 
 **Files:**
+
 - Create: `plugins/ml-research/agents/autoresearch-ideator.md`
 
 **Acceptance Criteria:**
+
 - [ ] File starts with valid YAML frontmatter containing `name: autoresearch-ideator`, `description: ...`, `model: opus`, `effort: medium`, `disallowedTools: Edit, Write` (read-only enforcement), and a `tools` allowlist that includes WebSearch, WebFetch, Read, Grep, Bash
 - [ ] System prompt body includes (each as a section heading):
   - Identity and scope (one experiment idea per dispatch, no disk writes)
@@ -339,6 +352,7 @@ git commit -m "Add autoresearch campaign templates (config.json, ideas.md, insig
 - [ ] Length is in the 400–600 line range (per spec)
 
 **Verify:**
+
 ```bash
 python3 -c "
 import yaml, sys
@@ -358,6 +372,7 @@ for required in ['Identity', 'Input contract', 'Output contract', 'Citation', 'C
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 **Steps:**
@@ -501,6 +516,7 @@ for required in ['Identity', 'Input contract', 'Output contract', 'Citation', 'C
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 - [ ] **Step 3: Commit**
@@ -518,6 +534,7 @@ git commit -m "Add autoresearch-ideator agent definition"
 **Goal:** Create `plugins/ml-research/agents/autoresearch-experimenter.md` — the system prompt for the subagent that runs one experiment end-to-end (implement, launch, monitor, analyze, with internal debug retry).
 
 **Spec sections to consult:**
+
 - § "Subagents → Default model + effort" (Experimenter row)
 - § "Subagents → Tool allowlists" (Experimenter row)
 - § "Subagents → Input contract"
@@ -532,9 +549,11 @@ git commit -m "Add autoresearch-ideator agent definition"
 - § "Data model → autoresearch/experiments/NNN-<slug>.md" (the narrative format Experimenter writes)
 
 **Files:**
+
 - Create: `plugins/ml-research/agents/autoresearch-experimenter.md`
 
 **Acceptance Criteria:**
+
 - [ ] Frontmatter has `name: autoresearch-experimenter`, `description: ...`, `model: sonnet`, `effort: medium`, `isolation: worktree`, and a `tools` allowlist (Bash, Read, Edit, Write, Grep, Monitor; Skill access for `ml-research:slurm` and `ml-research:model-training` is implicitly available via the Skill tool)
 - [ ] Body contains sections for: Identity, Input contract, Output contracts (both paths), Internal debug loop (with code-block pseudocode), Diagnosis→fix table (verbatim from spec), GPU utilization tracking, torch.compile cache invalidation rule, Acceptance criteria application, Narrative writing conventions, Hard rules
 - [ ] No SLURM-specific commands hardcoded — all environment-specific ops route through the env-appropriate skill (`ml-research:slurm` or whatever `entrypoints.launch_experiment.environment` indicates)
@@ -542,6 +561,7 @@ git commit -m "Add autoresearch-ideator agent definition"
 - [ ] Length is in the 600–800 line range (per spec)
 
 **Verify:**
+
 ```bash
 python3 -c "
 import yaml, sys
@@ -563,6 +583,7 @@ assert 'tail -f' not in body or 'do NOT' in body.lower() or 'must not' in body.l
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 **Steps:**
@@ -697,6 +718,7 @@ for required in ['Identity', 'Input contract', 'Output contract', 'debug loop', 
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 - [ ] **Step 3: Commit**
@@ -713,6 +735,7 @@ git commit -m "Add autoresearch-experimenter agent definition"
 **Goal:** Create `plugins/ml-research/agents/autoresearch-reviewer.md` — the system prompt for the subagent that synthesizes cross-experiment insights every 5 succeeded experiments.
 
 **Spec sections to consult:**
+
 - § "Subagents → Default model + effort" (Reviewer row)
 - § "Subagents → Tool allowlists" (Reviewer row)
 - § "Subagents → Input contract"
@@ -722,14 +745,17 @@ git commit -m "Add autoresearch-experimenter agent definition"
 - § "Subagents → Subagent hard rules" (Reviewer is read-only)
 
 **Files:**
+
 - Create: `plugins/ml-research/agents/autoresearch-reviewer.md`
 
 **Acceptance Criteria:**
+
 - [ ] Frontmatter has `name: autoresearch-reviewer`, `description: ...`, `model: opus`, `effort: medium`, `disallowedTools: Edit, Write, Bash` (effectively read-only — Bash allowed in read-only invocations only, but disallowing it entirely is simpler and the Reviewer doesn't need it), and `tools: Read, Grep`
 - [ ] Body contains sections for: Identity, Input contract, Output contract (insights delta JSON), Synthesis approach (pattern identification, not restatement), Proxy-overfit detection, Strategic-note guidelines, Hard rules
 - [ ] Length is in the 250-350 line range (per spec)
 
 **Verify:**
+
 ```bash
 python3 -c "
 import yaml, sys
@@ -749,6 +775,7 @@ for required in ['Identity', 'Input contract', 'Output contract', 'Synthesis', '
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 **Steps:**
@@ -874,6 +901,7 @@ for required in ['Identity', 'Input contract', 'Output contract', 'Synthesis', '
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 - [ ] **Step 3: Commit**
@@ -890,6 +918,7 @@ git commit -m "Add autoresearch-reviewer agent definition"
 **Goal:** Replace `plugins/ml-research/skills/autoresearch/SKILL.md` with a thin orchestrator prompt that handles Phase 0 setup interactively, runs the Phase 1 loop, owns trunk-side git ops, and dispatches the three subagents.
 
 **Spec sections to consult:**
+
 - § "Architecture" (overall actor map)
 - § "Phase 0: Setup" (full procedure)
 - § "Phase 1: Loop body" (full pseudocode, including resumption, idea selection, dispatch, post_experimenter handler)
@@ -899,9 +928,11 @@ git commit -m "Add autoresearch-reviewer agent definition"
 - § "Files & migration → SKILL.md shape"
 
 **Files:**
+
 - Replace: `plugins/ml-research/skills/autoresearch/SKILL.md`
 
 **Acceptance Criteria:**
+
 - [ ] Frontmatter has `name: autoresearch`, `description: ...` describing trigger conditions
 - [ ] Body has top-level sections for: Phase 0 (with subsections for invocation, decision flow, setup dialog, default constraints/themes, artifact init, initial commit), Phase 1 (loop body, resumption, idea selection, dispatch, git choreography, post_experimenter handler), Acceptance criteria, Retry policy, Autonomy principle
 - [ ] References to the three subagents use the correct `subagent_type` strings: `ml-research:autoresearch-ideator`, `ml-research:autoresearch-experimenter`, `ml-research:autoresearch-reviewer`
@@ -911,6 +942,7 @@ git commit -m "Add autoresearch-reviewer agent definition"
 - [ ] Length is in the 200-300 line range (per spec)
 
 **Verify:**
+
 ```bash
 python3 -c "
 import yaml
@@ -928,6 +960,7 @@ for forbidden in ['sbatch ', 'sacct ', 'squeue ', 'uv run harness fit', 'Lightni
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 **Steps:**
@@ -1072,6 +1105,7 @@ for forbidden in ['sbatch ', 'sacct ', 'squeue ', 'uv run harness fit', 'Lightni
 print('OK')
 "
 ```
+
 Expected: `OK`
 
 - [ ] **Step 4: Commit**
@@ -1090,6 +1124,7 @@ git commit -m "Rewrite autoresearch SKILL.md as thin orchestrator"
 **Files:** none modified.
 
 **Acceptance Criteria:**
+
 - [ ] `claude plugin validate plugins/ml-research/` exits 0
 - [ ] `claude plugin validate .` (marketplace.json) exits 0
 - [ ] All three agent files are syntactically discoverable (frontmatter parses; `name` field set)
@@ -1097,6 +1132,7 @@ git commit -m "Rewrite autoresearch SKILL.md as thin orchestrator"
 - [ ] No file in the plugin contains a leftover hardcoded reference to the old script paths (`scripts/count_params.py`, `scripts/launch.sbatch`)
 
 **Verify:**
+
 ```bash
 claude plugin validate plugins/ml-research/ 2>&1 | tee /tmp/validate.out \
   && claude plugin validate . 2>&1 | tee /tmp/validate-marketplace.out \
@@ -1113,6 +1149,7 @@ print('all agents OK')
        --include='*.md' --include='*.json' --include='*.yaml' \
   && echo OK
 ```
+
 Expected: `OK` (with the validate commands' own success output above it)
 
 **Steps:**
@@ -1124,6 +1161,7 @@ claude plugin validate plugins/ml-research/
 ```
 
 If this fails, read the error output carefully. Common issues:
+
 - Missing fields in frontmatter (the validator may flag these)
 - Invalid `tools:` allowlist values in agent frontmatter
 - File ref'd by SKILL.md that doesn't exist

--- a/docs/superpowers/plans/2026-04-24-autoresearch-redesign.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-24-autoresearch-redesign.md.tasks.json
@@ -1,0 +1,54 @@
+{
+  "planPath": "docs/superpowers/plans/2026-04-24-autoresearch-redesign.md",
+  "tasks": [
+    {
+      "id": 9,
+      "subject": "Task 0: Restructure files and directories",
+      "status": "pending",
+      "description": "**Goal:** Move existing scripts/templates/config to the new examples/ layout, create the agents/ directory, and delete the old templates that are being replaced.\n\n**Files:**\n- Create dir: `plugins/ml-research/agents/`\n- Create dir: `plugins/ml-research/skills/autoresearch/templates/examples/`\n- Move: `plugins/ml-research/skills/autoresearch/scripts/count_params.py` -> `templates/examples/count_params_lightning.py`\n- Move: `plugins/ml-research/skills/autoresearch/scripts/launch.sbatch` -> `templates/examples/launch_slurm_lightning.sbatch`\n- Move: `plugins/ml-research/skills/autoresearch/config.yaml` -> `templates/examples/lightning_trainer_config.yaml`\n- Delete: `scripts/`, `templates/autoresearch_ideas.md`, `autoresearch_log.md`, `autoresearch_results.csv`\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/agents/\", \"plugins/ml-research/skills/autoresearch/templates/examples/\"], \"verifyCommand\": \"test -d plugins/ml-research/agents/ && test -f plugins/ml-research/skills/autoresearch/templates/examples/count_params_lightning.py && test -f plugins/ml-research/skills/autoresearch/templates/examples/launch_slurm_lightning.sbatch && test -f plugins/ml-research/skills/autoresearch/templates/examples/lightning_trainer_config.yaml && ! test -d plugins/ml-research/skills/autoresearch/scripts/ && ! test -f plugins/ml-research/skills/autoresearch/config.yaml && echo OK\", \"acceptanceCriteria\": [\"agents/ dir exists\", \"examples/ dir has three files\", \"scripts/ deleted\", \"old autoresearch_ templates deleted\"], \"planTaskNumber\": 0}\n```"
+    },
+    {
+      "id": 10,
+      "subject": "Task 1: Write new template files",
+      "status": "pending",
+      "blockedBy": [9],
+      "description": "**Goal:** Create the four campaign-initialization templates (config.json, ideas.md, insights.md, results.csv).\n\n**Files:**\n- Create: `plugins/ml-research/skills/autoresearch/templates/config.json`\n- Create: `plugins/ml-research/skills/autoresearch/templates/ideas.md`\n- Create: `plugins/ml-research/skills/autoresearch/templates/insights.md`\n- Create: `plugins/ml-research/skills/autoresearch/templates/results.csv`\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/autoresearch/templates/config.json\", \"plugins/ml-research/skills/autoresearch/templates/ideas.md\", \"plugins/ml-research/skills/autoresearch/templates/insights.md\", \"plugins/ml-research/skills/autoresearch/templates/results.csv\"], \"verifyCommand\": \"python3 -c 'import json; json.load(open(\\\"plugins/ml-research/skills/autoresearch/templates/config.json\\\"))' && grep -q FIFO plugins/ml-research/skills/autoresearch/templates/ideas.md && grep -q '## Patterns observed' plugins/ml-research/skills/autoresearch/templates/insights.md && head -1 plugins/ml-research/skills/autoresearch/templates/results.csv | grep -q '^experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss$' && echo OK\", \"acceptanceCriteria\": [\"config.json valid JSON matching spec schema\", \"ideas.md has FIFO header\", \"insights.md has 4 standard sections\", \"results.csv has correct header row only\"], \"planTaskNumber\": 1}\n```"
+    },
+    {
+      "id": 11,
+      "subject": "Task 2: Author the Ideator agent definition",
+      "status": "pending",
+      "blockedBy": [9],
+      "description": "**Goal:** Create `plugins/ml-research/agents/autoresearch-ideator.md` -- system prompt for the subagent that generates one experiment idea with citations per dispatch. Spec sections: Subagents -> Default model+effort, Tool allowlists, Input/Output contracts, Sources requirements (4-tier), Curated source list, Proxy-task discipline, Hard rules.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/agents/autoresearch-ideator.md\"], \"verifyCommand\": \"python3 -c 'import yaml; content=open(\\\"plugins/ml-research/agents/autoresearch-ideator.md\\\").read(); parts=content.split(\\\"---\\\",2); fm=yaml.safe_load(parts[1]); assert fm[\\\"name\\\"]==\\\"autoresearch-ideator\\\"; assert fm[\\\"model\\\"]==\\\"opus\\\"; assert \\\"WebSearch\\\" in fm.get(\\\"tools\\\",[]); assert \\\"Edit\\\" in fm.get(\\\"disallowedTools\\\",[]); body=parts[2].lower(); [body.index(s) for s in [\\\"identity\\\",\\\"input contract\\\",\\\"output contract\\\",\\\"citation\\\",\\\"curated source\\\",\\\"proxy-task\\\",\\\"hard rules\\\"]]; print(\\\"OK\\\")'\", \"acceptanceCriteria\": [\"frontmatter has correct name/model/effort/tools/disallowedTools\", \"body has all required sections\", \"no SLURM/Lightning hardcoding\", \"length 400-600 lines\"], \"planTaskNumber\": 2}\n```"
+    },
+    {
+      "id": 12,
+      "subject": "Task 3: Author the Experimenter agent definition",
+      "status": "pending",
+      "blockedBy": [9],
+      "description": "**Goal:** Create `plugins/ml-research/agents/autoresearch-experimenter.md` -- system prompt for the subagent that runs one experiment end-to-end with internal debug retry. Spec sections: Subagents -> Default model+effort, Tool allowlists, Input/Output contracts (success+crash), Internal debug loop, Diagnosis->fix table, GPU utilization, torch.compile cache, Acceptance criteria, Proxy-task discipline, Hard rules, Experiment branch lifecycle, experiment file format.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/agents/autoresearch-experimenter.md\"], \"verifyCommand\": \"python3 -c 'import yaml; content=open(\\\"plugins/ml-research/agents/autoresearch-experimenter.md\\\").read(); parts=content.split(\\\"---\\\",2); fm=yaml.safe_load(parts[1]); assert fm[\\\"name\\\"]==\\\"autoresearch-experimenter\\\"; assert fm[\\\"model\\\"]==\\\"sonnet\\\"; assert fm.get(\\\"isolation\\\")==\\\"worktree\\\"; tools=fm.get(\\\"tools\\\",[]); [tools.index(t) for t in [\\\"Bash\\\",\\\"Read\\\",\\\"Edit\\\",\\\"Write\\\",\\\"Grep\\\",\\\"Monitor\\\"]]; body=parts[2].lower(); [body.index(s) for s in [\\\"identity\\\",\\\"input contract\\\",\\\"output contract\\\",\\\"debug loop\\\",\\\"diagnosis\\\",\\\"gpu utilization\\\",\\\"torch.compile\\\",\\\"acceptance criteria\\\",\\\"hard rules\\\"]]; print(\\\"OK\\\")'\", \"acceptanceCriteria\": [\"frontmatter correct (sonnet, isolation=worktree)\", \"body has all required sections\", \"no streaming of launch_experiment stdout/stderr\"], \"planTaskNumber\": 3}\n```"
+    },
+    {
+      "id": 13,
+      "subject": "Task 4: Author the Reviewer agent definition",
+      "status": "pending",
+      "blockedBy": [9],
+      "description": "**Goal:** Create `plugins/ml-research/agents/autoresearch-reviewer.md` -- system prompt for the subagent that synthesizes cross-experiment insights every 5 succeeded experiments. Spec sections: Subagents -> Default model+effort, Tool allowlists, Input/Output contracts, insights.md structure, Proxy-task discipline, Hard rules.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/agents/autoresearch-reviewer.md\"], \"verifyCommand\": \"python3 -c 'import yaml; content=open(\\\"plugins/ml-research/agents/autoresearch-reviewer.md\\\").read(); parts=content.split(\\\"---\\\",2); fm=yaml.safe_load(parts[1]); assert fm[\\\"name\\\"]==\\\"autoresearch-reviewer\\\"; assert fm[\\\"model\\\"]==\\\"opus\\\"; disallowed=fm.get(\\\"disallowedTools\\\",[]); assert \\\"Edit\\\" in disallowed; assert \\\"Write\\\" in disallowed; body=parts[2].lower(); [body.index(s) for s in [\\\"identity\\\",\\\"input contract\\\",\\\"output contract\\\",\\\"synthesis\\\",\\\"proxy-overfit\\\",\\\"strategic note\\\",\\\"hard rules\\\"]]; print(\\\"OK\\\")'\", \"acceptanceCriteria\": [\"frontmatter correct (opus, disallowedTools includes Edit/Write)\", \"body has all required sections\", \"length 250-350\"], \"planTaskNumber\": 4}\n```"
+    },
+    {
+      "id": 14,
+      "subject": "Task 5: Rewrite SKILL.md as the orchestrator prompt",
+      "status": "pending",
+      "blockedBy": [10, 11, 12, 13],
+      "description": "**Goal:** Replace `plugins/ml-research/skills/autoresearch/SKILL.md` with a thin orchestrator prompt: Phase 0 setup, Phase 1 loop, trunk-side git ops, dispatch of three subagents. Spec sections: Architecture, Phase 0/1 (full), Git choreography, Acceptance criteria, Retry policy, Autonomy principle, Subagents -> Input contract, SKILL.md shape.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/autoresearch/SKILL.md\"], \"verifyCommand\": \"python3 -c 'import yaml; content=open(\\\"plugins/ml-research/skills/autoresearch/SKILL.md\\\").read(); parts=content.split(\\\"---\\\",2); fm=yaml.safe_load(parts[1]); assert fm[\\\"name\\\"]==\\\"autoresearch\\\"; body=parts[2].lower(); [body.index(s) for s in [\\\"phase 0\\\",\\\"phase 1\\\",\\\"acceptance criteria\\\",\\\"retry policy\\\",\\\"autonomy\\\",\\\"autoresearch-ideator\\\",\\\"autoresearch-experimenter\\\",\\\"autoresearch-reviewer\\\",\\\"training_objective\\\",\\\"experiment_budget\\\",\\\"read_metrics\\\"]]; assert \\\"sbatch \\\" not in body; assert \\\"sacct \\\" not in body; assert \\\"squeue \\\" not in body; assert \\\"lightningmodule\\\" not in body; assert \\\"jsonargparse\\\" not in body; print(\\\"OK\\\")'\", \"acceptanceCriteria\": [\"frontmatter correct\", \"all required sections present\", \"subagent_type strings correct\", \"no SLURM/Lightning hardcoding\", \"length 200-300 lines\"], \"planTaskNumber\": 5}\n```"
+    },
+    {
+      "id": 15,
+      "subject": "Task 6: Plugin validation and integration smoke test",
+      "status": "pending",
+      "blockedBy": [14],
+      "description": "**Goal:** Verify the plugin manifest is still valid after restructuring; run an end-to-end check.\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"claude plugin validate plugins/ml-research/ && claude plugin validate . && python3 -c 'import yaml,glob; [yaml.safe_load(open(f).read().split(\\\"---\\\",2)[1]) for f in glob.glob(\\\"plugins/ml-research/agents/*.md\\\")]; print(\\\"agents OK\\\")' && ! grep -r 'scripts/count_params.py\\\\|scripts/launch.sbatch' plugins/ml-research/ --include='*.md' --include='*.json' --include='*.yaml' && echo OK\", \"acceptanceCriteria\": [\"plugin validate exits 0\", \"marketplace validate exits 0\", \"all agent frontmatter parseable\", \"no legacy script-path references\"], \"planTaskNumber\": 6}\n```"
+    }
+  ],
+  "lastUpdated": "2026-04-24T00:00:00Z"
+}

--- a/docs/superpowers/plans/2026-04-26-getitem-profiler.md
+++ b/docs/superpowers/plans/2026-04-26-getitem-profiler.md
@@ -6,7 +6,9 @@
 
 **Architecture:** The skill is a markdown orchestration prompt (`SKILL.md`) that drives a greedy edit loop, plus a single-file Python harness (`scripts/profile_getitem.py`) that owns all measurement work. The harness exposes two subcommands — `baseline` (cache outputs + record starting timings) and `measure` (re-run cached indices, equality-check, re-profile, compute deltas) — each printing JSON. The skill never touches the user's dataset directly; it only invokes the harness and reads JSON.
 
-**Tech Stack:** Python 3.10+, `line_profiler` (programmatic API: `LineProfiler.add_class` + `add_module` with `ScopingPolicy.LOCAL`, NOT `kernprof`/`autoprofile.run`), `torch`, `numpy`, `PIL`, `pickle`. The user's environment is assumed to have these — the harness imports them directly. Markdown with YAML frontmatter for `SKILL.md`.
+**Tech Stack:** Python 3.10+, `line_profiler` 5.x (programmatic API: `LineProfiler.add_class` + `add_module` with `ScopingPolicy.CHILDREN`, NOT `kernprof`/`autoprofile.run`), `torch`, `numpy`, `PIL`, `pickle`. The user's environment is assumed to have these — the harness imports them directly. Markdown with YAML frontmatter for `SKILL.md`.
+
+**Environment for running verify blocks:** This repo's torch venv is `/u/jschmidt3/autoresearch/.venv/bin/python` (system `python3` lacks torch). All `python3` references in verify blocks below should be substituted with that interpreter. Install missing deps via `uv pip install <pkg> --python /u/jschmidt3/autoresearch/.venv/bin/python`.
 
 **Spec:** `docs/superpowers/specs/2026-04-26-getitem-profiler-design.md` is the source of truth for any detail not spelled out in this plan.
 
@@ -482,7 +484,8 @@ assert b['reliable_line_stats'] is True
 assert len(b['indices']) == 4
 top = sorted(b['line_stats'], key=lambda x: x['pct'], reverse=True)[0]
 assert top['pct'] > 50, f'expected hotspot >50%, got {top}'
-assert 'for j in range' in top['code'] or 'for i in range' in top['code'], top
+# Top hotspot is the per-pixel loop *body*; the for-headers will rank lower.
+assert 'arr[i, j]' in top['code'] or 'out[i, j]' in top['code'], top
 assert all(pathlib.Path(f'/tmp/getitem-profile-test/baseline/{i}.pkl').exists() for i in range(4))
 print('OK strict')
 " && \
@@ -560,15 +563,15 @@ def run_line_profiler(dataset, indices: list[int], seed_base: int, profile_scope
     prof = LineProfiler()
     cls = type(dataset)
     mod = sys.modules[cls.__module__]
-    prof.add_class(cls, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
-    prof.add_module(mod, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+    prof.add_class(cls, scoping_policy=ScopingPolicy.CHILDREN, wrap=True)
+    prof.add_module(mod, scoping_policy=ScopingPolicy.CHILDREN, wrap=True)
     if profile_scope == "package":
         top = cls.__module__.split(".")[0]
         for name, m in list(sys.modules.items()):
             if name == cls.__module__:
                 continue
             if (name == top or name.startswith(top + ".")) and m is not None:
-                prof.add_module(m, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+                prof.add_module(m, scoping_policy=ScopingPolicy.CHILDREN, wrap=True)
 
     prof.enable_by_count()
     try:

--- a/docs/superpowers/plans/2026-04-26-getitem-profiler.md
+++ b/docs/superpowers/plans/2026-04-26-getitem-profiler.md
@@ -1,0 +1,1357 @@
+# `getitem-profiler` skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a new skill `ml-research:getitem-profiler` that greedily optimizes `Dataset.__getitem__` line-by-line on a side branch, gating each edit on byte-identical outputs (under seeded RNGs) and a meaningful per-call speedup, per the design at `docs/superpowers/specs/2026-04-26-getitem-profiler-design.md`.
+
+**Architecture:** The skill is a markdown orchestration prompt (`SKILL.md`) that drives a greedy edit loop, plus a single-file Python harness (`scripts/profile_getitem.py`) that owns all measurement work. The harness exposes two subcommands — `baseline` (cache outputs + record starting timings) and `measure` (re-run cached indices, equality-check, re-profile, compute deltas) — each printing JSON. The skill never touches the user's dataset directly; it only invokes the harness and reads JSON.
+
+**Tech Stack:** Python 3.10+, `line_profiler` (programmatic API: `LineProfiler.add_class` + `add_module` with `ScopingPolicy.LOCAL`, NOT `kernprof`/`autoprofile.run`), `torch`, `numpy`, `PIL`, `pickle`. The user's environment is assumed to have these — the harness imports them directly. Markdown with YAML frontmatter for `SKILL.md`.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-getitem-profiler-design.md` is the source of truth for any detail not spelled out in this plan.
+
+---
+
+## File structure
+
+After this plan completes:
+
+```
+plugins/ml-research/skills/getitem-profiler/
+├── SKILL.md                              # NEW — orchestration prompt
+├── scripts/
+│   └── profile_getitem.py                # NEW — measurement harness
+└── tests/
+    └── fixtures/
+        ├── tiny_image_dataset.py         # NEW — deterministic synthetic dataset
+        ├── nondeterministic_dataset.py   # NEW — fails seed-based determinism
+        └── README.md                     # NEW — describes the fixtures
+```
+
+Tests are exercised manually via the harness CLI during development — there is no pytest suite (the project has no Python test infra). The fixtures ship with the skill so a future maintainer can re-run the smoke tests.
+
+---
+
+## Tasks
+
+### Task 0: Scaffold skill directory and synthetic test fixtures
+
+**Goal:** Lay down the skill's directory structure with placeholder files that the next tasks will fill in, plus two synthetic datasets the harness can be exercised against during development.
+
+**Files:**
+
+- Create: `plugins/ml-research/skills/getitem-profiler/SKILL.md` (frontmatter-only stub for now)
+- Create: `plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py` (empty `main()`)
+- Create: `plugins/ml-research/skills/getitem-profiler/tests/fixtures/tiny_image_dataset.py`
+- Create: `plugins/ml-research/skills/getitem-profiler/tests/fixtures/nondeterministic_dataset.py`
+- Create: `plugins/ml-research/skills/getitem-profiler/tests/fixtures/README.md`
+
+**Acceptance Criteria:**
+
+- [ ] The skill is discoverable by Claude Code (frontmatter parses, `name: getitem-profiler`, has a non-empty `description`)
+- [ ] `scripts/profile_getitem.py` is executable and prints usage when run with no args
+- [ ] `tiny_image_dataset.py:make_dataset()` returns an instance whose `__getitem__(0)` returns a dict with a `"image"` torch tensor and `"label"` int, takes > 1 ms per call, and produces byte-identical outputs across two seeded calls
+- [ ] `nondeterministic_dataset.py:make_dataset()` returns an instance whose `__getitem__(0)` differs across two seeded calls (uses `os.urandom`, deliberately bypassing standard RNGs)
+
+**Verify:**
+
+```bash
+python3 -c "
+import sys
+sys.path.insert(0, 'plugins/ml-research/skills/getitem-profiler/tests/fixtures')
+import torch, numpy as np, random
+
+# Tiny dataset: deterministic under seeded RNGs
+import tiny_image_dataset
+ds = tiny_image_dataset.make_dataset()
+def seed_all(s):
+    torch.manual_seed(s); np.random.seed(s); random.seed(s)
+seed_all(0); a = ds[0]
+seed_all(0); b = ds[0]
+assert torch.equal(a['image'], b['image']), 'tiny_image_dataset is not deterministic under seed'
+assert a['label'] == b['label']
+assert isinstance(a['image'], torch.Tensor)
+import time
+seed_all(0); t0 = time.perf_counter(); _ = ds[0]; dt = time.perf_counter() - t0
+assert dt > 1e-3, f'tiny_image_dataset is too fast to profile: {dt*1000:.2f} ms'
+
+# Nondet dataset: differs across seeded calls
+import nondeterministic_dataset
+nd = nondeterministic_dataset.make_dataset()
+seed_all(0); a = nd[0]; seed_all(0); b = nd[0]
+assert not torch.equal(a['value'], b['value']), 'nondeterministic_dataset is unexpectedly deterministic'
+
+print('OK')
+"
+```
+
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Create the skill directory tree**
+
+```bash
+mkdir -p plugins/ml-research/skills/getitem-profiler/scripts
+mkdir -p plugins/ml-research/skills/getitem-profiler/tests/fixtures
+```
+
+- [ ] **Step 2: Write the SKILL.md frontmatter stub**
+
+The full body comes in Task 4. For now, just enough that the skill loader picks it up.
+
+```markdown
+---
+name: getitem-profiler
+description: Profile Dataset.__getitem__ with line_profiler and greedily optimize the slowest line on a side branch, gated by output equality and a per-call speedup threshold. Use when the user says "__getitem__ is slow", "profile my dataset", "speed up my dataloader", or supplies a factory function and asks for optimization.
+---
+
+(Body filled in by Task 4.)
+```
+
+Save to `plugins/ml-research/skills/getitem-profiler/SKILL.md`.
+
+- [ ] **Step 3: Write the harness shell**
+
+```python
+#!/usr/bin/env python3
+"""getitem-profiler measurement harness.
+
+See plugins/ml-research/skills/getitem-profiler/SKILL.md for the orchestration
+prompt that drives this script.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="profile_getitem.py")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("baseline")
+    sub.add_parser("measure")
+    args = parser.parse_args(argv)
+    print(f"stub: cmd={args.cmd}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Save to `plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py`. Then `chmod +x` it:
+
+```bash
+chmod +x plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+```
+
+- [ ] **Step 4: Write `tiny_image_dataset.py`**
+
+Deterministic-under-seed synthetic dataset with a clear line-profiler hotspot (the per-pixel Python loop is intentionally slow so the harness has something to optimize during smoke tests).
+
+```python
+"""Synthetic dataset with a clear line_profiler hotspot.
+
+Used to exercise the getitem-profiler harness during development. The per-pixel
+Python loop in __getitem__ is the intentional bottleneck.
+"""
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+
+class TinyImageDataset:
+    def __init__(self, n: int = 32, side: int = 48) -> None:
+        self.n = n
+        self.side = side
+        # Per-index seeds so output depends only on idx (and the global RNG state
+        # at call time, which the harness controls via seed_all).
+        self._seeds = np.arange(n, dtype=np.int64)
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, idx: int) -> dict:
+        rng = np.random.default_rng(int(self._seeds[idx]))
+        arr = rng.uniform(0, 1, (self.side, self.side, 3)).astype(np.float32)
+        # Intentional hotspot: per-pixel Python loop — line_profiler will rank
+        # this line as the slowest. Vectorizing it (`out = arr * 2.0 - 1.0`)
+        # is the obvious optimization the harness would propose.
+        out = np.empty_like(arr)
+        for i in range(self.side):
+            for j in range(self.side):
+                out[i, j] = arr[i, j] * 2.0 - 1.0
+        img = torch.from_numpy(out).permute(2, 0, 1).contiguous()
+        return {"image": img, "label": int(idx % 10)}
+
+
+def make_dataset() -> TinyImageDataset:
+    return TinyImageDataset()
+```
+
+Save to `plugins/ml-research/skills/getitem-profiler/tests/fixtures/tiny_image_dataset.py`.
+
+- [ ] **Step 5: Write `nondeterministic_dataset.py`**
+
+```python
+"""Synthetic dataset that bypasses seed-based determinism.
+
+Used to verify the harness's `equality_mode: non_deterministic` detection.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+class NondeterministicDataset:
+    def __len__(self) -> int:
+        return 32
+
+    def __getitem__(self, idx: int) -> dict:
+        # os.urandom isn't affected by torch.manual_seed / np.random.seed /
+        # random.seed — the harness should detect this and refuse to start
+        # the greedy loop.
+        n = int.from_bytes(os.urandom(4), "little")
+        return {"value": torch.tensor(float(n))}
+
+
+def make_dataset() -> NondeterministicDataset:
+    return NondeterministicDataset()
+```
+
+Save to `plugins/ml-research/skills/getitem-profiler/tests/fixtures/nondeterministic_dataset.py`.
+
+- [ ] **Step 6: Write a brief README for the fixtures**
+
+```markdown
+# Test fixtures
+
+Synthetic datasets used to exercise `scripts/profile_getitem.py` during development. There is no pytest suite — fixtures are imported via the harness's `--factory` flag.
+
+- `tiny_image_dataset.py:make_dataset` — deterministic under seeded RNGs, intentionally slow per-pixel loop in `__getitem__` so line_profiler has a clear hotspot to surface.
+- `nondeterministic_dataset.py:make_dataset` — uses `os.urandom`, deliberately bypassing standard RNGs. The harness should detect this and emit `equality_mode: non_deterministic` in `baseline.json`.
+```
+
+Save to `plugins/ml-research/skills/getitem-profiler/tests/fixtures/README.md`.
+
+- [ ] **Step 7: Run the verify command**
+
+Run the multi-line python verify command from the **Verify** section above.
+
+Expected: `OK`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add plugins/ml-research/skills/getitem-profiler/
+git commit -m "Scaffold getitem-profiler skill and synthetic test fixtures"
+```
+
+---
+
+### Task 1: Implement equality walker
+
+**Goal:** Implement `deep_equal(a, b)` in `profile_getitem.py` — recursively compares dicts, lists, tuples, tensors, numpy arrays, PIL Images, and primitive types, returning `(passed, first_diff_path, summary)`. This is the core safety net behind every accepted edit.
+
+**Files:**
+
+- Modify: `plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py` (add equality + helper imports)
+
+**Acceptance Criteria:**
+
+- [ ] `deep_equal(x, x)` returns `(True, None, None)` for tensors, numpy arrays, dicts, lists, tuples, ints, floats, strings, None, PIL Images
+- [ ] `deep_equal({"a": tensor1}, {"a": tensor2})` with `tensor1 != tensor2` returns `(False, "outputs.a", <summary mentioning shape or value>)`
+- [ ] `deep_equal({"a": 1}, {"a": 1, "b": 2})` returns `(False, "outputs", "key sets differ: ...")`
+- [ ] `deep_equal([1, 2], [1, 3])` returns `(False, "outputs[1]", ...)`
+- [ ] Different dtypes count as unequal (e.g. `tensor(1.0, float32)` vs `tensor(1.0, float64)`)
+- [ ] PIL Image equality compares `.tobytes()` and `.size` and `.mode`
+- [ ] Unknown leaf types fall back to `==` and capture exceptions
+
+**Verify:**
+
+```bash
+python3 -c "
+import sys
+sys.path.insert(0, 'plugins/ml-research/skills/getitem-profiler/scripts')
+import torch, numpy as np
+from PIL import Image
+from profile_getitem import deep_equal
+
+# Equal cases
+assert deep_equal(torch.zeros(3), torch.zeros(3)) == (True, None, None)
+assert deep_equal(np.zeros(3), np.zeros(3)) == (True, None, None)
+assert deep_equal({'a': 1, 'b': [2, 3]}, {'a': 1, 'b': [2, 3]}) == (True, None, None)
+img = Image.new('RGB', (4, 4), (255, 0, 0))
+img2 = Image.new('RGB', (4, 4), (255, 0, 0))
+assert deep_equal(img, img2) == (True, None, None)
+
+# Unequal cases
+ok, path, _ = deep_equal({'a': torch.zeros(3)}, {'a': torch.ones(3)})
+assert not ok and path == 'outputs.a'
+ok, path, _ = deep_equal({'a': 1}, {'a': 1, 'b': 2})
+assert not ok and path == 'outputs'
+ok, path, _ = deep_equal([1, 2], [1, 3])
+assert not ok and path == 'outputs[1]'
+ok, _, _ = deep_equal(torch.zeros(3, dtype=torch.float32), torch.zeros(3, dtype=torch.float64))
+assert not ok, 'dtype mismatch should fail'
+
+print('OK')
+"
+```
+
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Replace `profile_getitem.py` with the equality walker added**
+
+The walker handles the leaf types named in the spec § "Data model → measure-N.json". Keep the `main()` stub — it'll be filled in over the next tasks.
+
+```python
+#!/usr/bin/env python3
+"""getitem-profiler measurement harness.
+
+See plugins/ml-research/skills/getitem-profiler/SKILL.md for the orchestration
+prompt that drives this script.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+
+def deep_equal(a: Any, b: Any, _path: str = "outputs") -> tuple[bool, str | None, str | None]:
+    """Recursively compare two outputs.
+
+    Returns (True, None, None) on equal; (False, first_diff_path, summary) on mismatch.
+    Handles dicts, lists, tuples, torch tensors, numpy arrays, PIL Images, and
+    primitive types. Unknown leaf types fall back to ==.
+    """
+    # Handle types in order: containers first, then leaf types.
+    if isinstance(a, dict) or isinstance(b, dict):
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if set(a.keys()) != set(b.keys()):
+            return False, _path, f"key sets differ: {sorted(a.keys())} vs {sorted(b.keys())}"
+        for k in a:
+            ok, p, s = deep_equal(a[k], b[k], f"{_path}.{k}")
+            if not ok:
+                return False, p, s
+        return True, None, None
+
+    if isinstance(a, (list, tuple)) or isinstance(b, (list, tuple)):
+        if type(a) is not type(b):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if len(a) != len(b):
+            return False, _path, f"length mismatch: {len(a)} vs {len(b)}"
+        for i, (ai, bi) in enumerate(zip(a, b)):
+            ok, p, s = deep_equal(ai, bi, f"{_path}[{i}]")
+            if not ok:
+                return False, p, s
+        return True, None, None
+
+    # Lazy imports so the equality module doesn't hard-require torch/numpy/PIL
+    # to be importable at module load (the harness imports them at top level
+    # anyway, but keeping deep_equal robust in isolation makes it easier to
+    # smoke-test).
+    try:
+        import torch  # type: ignore
+    except ImportError:
+        torch = None  # type: ignore
+    try:
+        import numpy as np  # type: ignore
+    except ImportError:
+        np = None  # type: ignore
+    try:
+        from PIL import Image  # type: ignore
+    except ImportError:
+        Image = None  # type: ignore
+
+    if torch is not None and (isinstance(a, torch.Tensor) or isinstance(b, torch.Tensor)):
+        if not (isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if a.shape != b.shape:
+            return False, _path, f"tensor shape {tuple(a.shape)} vs {tuple(b.shape)}"
+        if a.dtype != b.dtype:
+            return False, _path, f"tensor dtype {a.dtype} vs {b.dtype}"
+        if not torch.equal(a, b):
+            return False, _path, "tensor values differ"
+        return True, None, None
+
+    if np is not None and (isinstance(a, np.ndarray) or isinstance(b, np.ndarray)):
+        if not (isinstance(a, np.ndarray) and isinstance(b, np.ndarray)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if a.shape != b.shape:
+            return False, _path, f"array shape {a.shape} vs {b.shape}"
+        if a.dtype != b.dtype:
+            return False, _path, f"array dtype {a.dtype} vs {b.dtype}"
+        if not np.array_equal(a, b):
+            return False, _path, "array values differ"
+        return True, None, None
+
+    if Image is not None and (isinstance(a, Image.Image) or isinstance(b, Image.Image)):
+        if not (isinstance(a, Image.Image) and isinstance(b, Image.Image)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if a.size != b.size:
+            return False, _path, f"PIL size {a.size} vs {b.size}"
+        if a.mode != b.mode:
+            return False, _path, f"PIL mode {a.mode} vs {b.mode}"
+        if a.tobytes() != b.tobytes():
+            return False, _path, "PIL pixel bytes differ"
+        return True, None, None
+
+    # Fallback: ==, capturing exceptions.
+    try:
+        if a == b:
+            return True, None, None
+        return False, _path, f"{type(a).__name__} != {type(b).__name__}: {a!r} vs {b!r}"
+    except Exception as e:  # noqa: BLE001
+        return False, _path, f"comparison failed for {type(a).__name__}: {e}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="profile_getitem.py")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("baseline")
+    sub.add_parser("measure")
+    args = parser.parse_args(argv)
+    print(f"stub: cmd={args.cmd}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Save the file (overwriting Task 0's stub).
+
+- [ ] **Step 2: Run the verify command**
+
+Run the python verify block from the **Verify** section.
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+git commit -m "Add deep_equal walker for getitem-profiler harness"
+```
+
+---
+
+### Task 2: Implement `baseline` subcommand end-to-end
+
+**Goal:** Implement `profile_getitem.py baseline` — load the user's factory, seed RNGs, call `__getitem__` for the requested indices, run the determinism self-check, run line_profiler, run the DataLoader micro-benchmark, write `baseline.json` and pickled outputs to the out-dir.
+
+**Files:**
+
+- Modify: `plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py`
+
+**Acceptance Criteria:**
+
+- [ ] `profile_getitem.py baseline --factory tiny_image_dataset:make_dataset` writes `<out-dir>/baseline.json` and `<out-dir>/baseline/{0..7}.pkl`
+- [ ] `baseline.json` has the keys: `factory, indices, seed_base, equality_mode, reliable_line_stats, per_call_wall_time_s, line_stats, dataloader_bench`
+- [ ] On `tiny_image_dataset`, `equality_mode == "strict"` and `reliable_line_stats == true`
+- [ ] On `tiny_image_dataset`, the top entry of `line_stats` (sorted by `pct` descending) is the per-pixel loop line, with `pct > 50`
+- [ ] On `nondeterministic_dataset`, `equality_mode == "non_deterministic"`, `first_diff_path` is set, and the script exits 0 (skill handles the case)
+- [ ] `--profile-scope local` is the default; `--profile-scope package` walks sibling modules in the dataset's top-level package
+- [ ] `--num-indices 8`, `--num-workers 4`, `--bench-batches 50` are the defaults; all overridable
+- [ ] `--out-dir` defaults to `.getitem-profile`
+
+**Verify:**
+
+```bash
+cd plugins/ml-research/skills/getitem-profiler && \
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py baseline \
+    --factory tiny_image_dataset:make_dataset \
+    --num-indices 4 \
+    --num-workers 2 \
+    --bench-batches 10 \
+    --out-dir /tmp/getitem-profile-test && \
+python3 -c "
+import json, pathlib
+b = json.loads(pathlib.Path('/tmp/getitem-profile-test/baseline.json').read_text())
+assert b['equality_mode'] == 'strict', b['equality_mode']
+assert b['reliable_line_stats'] is True
+assert len(b['indices']) == 4
+top = sorted(b['line_stats'], key=lambda x: x['pct'], reverse=True)[0]
+assert top['pct'] > 50, f'expected hotspot >50%, got {top}'
+assert 'for j in range' in top['code'] or 'for i in range' in top['code'], top
+assert all(pathlib.Path(f'/tmp/getitem-profile-test/baseline/{i}.pkl').exists() for i in range(4))
+print('OK strict')
+" && \
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py baseline \
+    --factory nondeterministic_dataset:make_dataset \
+    --num-indices 4 --num-workers 2 --bench-batches 10 \
+    --out-dir /tmp/getitem-profile-nondet && \
+python3 -c "
+import json, pathlib
+b = json.loads(pathlib.Path('/tmp/getitem-profile-nondet/baseline.json').read_text())
+assert b['equality_mode'] == 'non_deterministic', b
+assert b.get('first_diff_path'), b
+print('OK non_deterministic')
+"
+```
+
+Expected output (last lines): `OK strict` then `OK non_deterministic`.
+
+**Steps:**
+
+- [ ] **Step 1: Add the imports and core helpers (factory loading, RNG seeding, line_profiler integration, dataloader bench)**
+
+Add these to `profile_getitem.py` near the top, after the `deep_equal` definition. The `RELIABLE_LINE_STATS_THRESHOLD_S` constant matches the spec's "below ~1 ms" wording.
+
+```python
+import importlib
+import json
+import pickle
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+
+RELIABLE_LINE_STATS_THRESHOLD_S = 1e-3  # below this, line_profiler overhead dominates
+
+
+def load_factory(spec: str) -> Callable:
+    """Resolve 'pkg.mod:attr' to a callable factory."""
+    if ":" not in spec:
+        raise ValueError(f"--factory must be 'pkg.mod:attr', got {spec!r}")
+    mod_path, attr = spec.split(":", 1)
+    mod = importlib.import_module(mod_path)
+    fn = getattr(mod, attr)
+    if not callable(fn):
+        raise TypeError(f"{spec} is not callable")
+    return fn
+
+
+def seed_all(seed: int) -> None:
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+
+
+def call_one(dataset, idx: int, seed_base: int):
+    """Seed RNGs and call dataset[idx]. Returns (output, wall_time_s) or raises."""
+    seed_all(seed_base + idx)
+    t0 = time.perf_counter()
+    out = dataset[idx]
+    dt = time.perf_counter() - t0
+    return out, dt
+
+
+def run_line_profiler(dataset, indices: list[int], seed_base: int, profile_scope: str):
+    """Returns the list of line_stats dicts (file, function, line, code, hits, time_s, pct)."""
+    from line_profiler import LineProfiler  # type: ignore
+    from line_profiler.scoping_policy import ScopingPolicy  # type: ignore
+
+    prof = LineProfiler()
+    cls = type(dataset)
+    mod = sys.modules[cls.__module__]
+    prof.add_class(cls, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+    prof.add_module(mod, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+    if profile_scope == "package":
+        top = cls.__module__.split(".")[0]
+        for name, m in list(sys.modules.items()):
+            if name == cls.__module__:
+                continue
+            if (name == top or name.startswith(top + ".")) and m is not None:
+                prof.add_module(m, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+
+    prof.enable_by_count()
+    try:
+        for i in indices:
+            seed_all(seed_base + i)
+            _ = dataset[i]
+    finally:
+        prof.disable_by_count()
+
+    stats = prof.get_stats()
+    # Build per-line dicts. stats.timings: {(filename, lineno_start, name): [(lineno, hits, time_us)]}
+    # Convert microseconds to seconds; compute pct vs sum of all timed lines.
+    rows = []
+    for (filename, _start_lineno, fn_name), entries in stats.timings.items():
+        # Pull source lines for the `code` field.
+        try:
+            source = Path(filename).read_text().splitlines()
+        except OSError:
+            source = []
+        for lineno, hits, time_us in entries:
+            time_s = time_us * stats.unit  # stats.unit is the conversion to seconds
+            code = source[lineno - 1].strip() if 0 < lineno <= len(source) else ""
+            rows.append({
+                "file": filename,
+                "function": fn_name,
+                "line": lineno,
+                "code": code,
+                "hits": hits,
+                "time_s": time_s,
+            })
+    total = sum(r["time_s"] for r in rows) or 1.0
+    for r in rows:
+        r["pct"] = round(100.0 * r["time_s"] / total, 2)
+    rows.sort(key=lambda r: r["time_s"], reverse=True)
+    return rows
+
+
+def run_dataloader_bench(dataset, num_workers: int, batch_size: int, batches: int) -> dict:
+    """Run a short DataLoader iteration. Drops the first batch (worker warmup)."""
+    loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        shuffle=False,
+        drop_last=True,
+    )
+    timings: list[float] = []
+    it = iter(loader)
+    # Warmup batch
+    try:
+        next(it)
+    except StopIteration:
+        pass
+    for _ in range(batches):
+        t0 = time.perf_counter()
+        try:
+            next(it)
+        except StopIteration:
+            break
+        timings.append(time.perf_counter() - t0)
+    if not timings:
+        return {
+            "num_workers": num_workers,
+            "batch_size": batch_size,
+            "batches_measured": 0,
+            "batches_per_sec": 0.0,
+            "mean_batch_latency_s": 0.0,
+        }
+    mean_latency = sum(timings) / len(timings)
+    return {
+        "num_workers": num_workers,
+        "batch_size": batch_size,
+        "batches_measured": len(timings),
+        "batches_per_sec": 1.0 / mean_latency if mean_latency > 0 else 0.0,
+        "mean_batch_latency_s": mean_latency,
+    }
+```
+
+- [ ] **Step 2: Add the `cmd_baseline` function**
+
+```python
+def cmd_baseline(args) -> int:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "baseline").mkdir(exist_ok=True)
+
+    factory = load_factory(args.factory)
+    dataset = factory()
+
+    if args.indices:
+        indices = [int(x) for x in args.indices.split(",")]
+    else:
+        indices = list(range(args.num_indices))
+    seed_base = args.seed_base
+
+    # Determinism self-check: call each index twice, compare.
+    per_call_times: list[float] = []
+    cached_outputs: list = []
+    for i in indices:
+        out_a, dt = call_one(dataset, i, seed_base)
+        out_b, _ = call_one(dataset, i, seed_base)
+        ok, diff_path, summary = deep_equal(out_a, out_b)
+        if not ok:
+            payload = {
+                "factory": args.factory,
+                "indices": indices,
+                "seed_base": seed_base,
+                "equality_mode": "non_deterministic",
+                "first_diff_path": diff_path,
+                "summary": summary,
+            }
+            (out_dir / "baseline.json").write_text(json.dumps(payload, indent=2))
+            return 0
+        per_call_times.append(dt)
+        cached_outputs.append(out_a)
+
+    # Cache outputs.
+    for i, out in zip(indices, cached_outputs):
+        with open(out_dir / "baseline" / f"{i}.pkl", "wb") as f:
+            pickle.dump(out, f)
+
+    mean_per_call = sum(per_call_times) / len(per_call_times)
+    reliable = mean_per_call >= RELIABLE_LINE_STATS_THRESHOLD_S
+
+    # Line profiler.
+    line_stats = run_line_profiler(dataset, indices, seed_base, args.profile_scope)
+
+    # DataLoader bench. (Re-instantiate so workers don't share state from above.)
+    bench_dataset = factory()
+    bench = run_dataloader_bench(
+        bench_dataset, args.num_workers, args.batch_size, args.bench_batches
+    )
+
+    payload = {
+        "factory": args.factory,
+        "indices": indices,
+        "seed_base": seed_base,
+        "equality_mode": "strict",
+        "reliable_line_stats": reliable,
+        "per_call_wall_time_s": {
+            "mean": mean_per_call,
+            "indices": per_call_times,
+        },
+        "line_stats": line_stats,
+        "dataloader_bench": bench,
+    }
+    (out_dir / "baseline.json").write_text(json.dumps(payload, indent=2))
+    return 0
+```
+
+- [ ] **Step 3: Wire up the argparse subcommand**
+
+Replace the stub `main()` with:
+
+```python
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="profile_getitem.py")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_b = sub.add_parser("baseline")
+    p_b.add_argument("--factory", required=True, help="pkg.mod:attr factory function")
+    p_b.add_argument("--num-indices", type=int, default=8)
+    p_b.add_argument("--indices", type=str, default="", help="comma-separated, overrides --num-indices")
+    p_b.add_argument("--profile-scope", choices=["local", "package"], default="local")
+    p_b.add_argument("--num-workers", type=int, default=4)
+    p_b.add_argument("--batch-size", type=int, default=16)
+    p_b.add_argument("--bench-batches", type=int, default=50)
+    p_b.add_argument("--seed-base", type=int, default=0)
+    p_b.add_argument("--out-dir", type=str, default=".getitem-profile")
+    p_b.set_defaults(func=cmd_baseline)
+
+    p_m = sub.add_parser("measure")
+    # Filled in by Task 3.
+    p_m.set_defaults(func=lambda a: (print("not yet implemented", file=sys.stderr), 1)[1])
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+```
+
+- [ ] **Step 4: Run the verify command from the Verify section**
+
+(Same multi-step bash + python block.) Expected: `OK strict` then `OK non_deterministic`.
+
+If the verify fails on `pct > 50` for the hotspot line, double-check that `wrap=True` was passed to `add_class` — without it the bound `__getitem__` invoked through `dataset[idx]` may bypass the profiler.
+
+If `equality_mode != "non_deterministic"` for the second fixture, verify that `nondeterministic_dataset.__getitem__` is using `os.urandom` (not anything seeded).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+git commit -m "Implement baseline subcommand for getitem-profiler harness"
+```
+
+---
+
+### Task 3: Implement `measure` subcommand end-to-end
+
+**Goal:** Implement `profile_getitem.py measure` — load the (potentially edited) factory, equality-check against the cached baseline outputs, re-profile, compute `delta_vs_baseline` and `delta_vs_prev_accepted`, write `measure-N.json`. Failures (equality mismatch, raised exception in `__getitem__`, dataloader-bench failure) all surface through the `equality.passed: false` shape — no special status codes.
+
+**Files:**
+
+- Modify: `plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py`
+
+**Acceptance Criteria:**
+
+- [ ] `profile_getitem.py measure --factory ... --baseline-dir ...` writes the next available `measure-N.json`
+- [ ] On the unmodified `tiny_image_dataset`, `equality.passed == true` and `delta_vs_prev_accepted.per_call_speedup_x ≈ 1.0` (within ±10%)
+- [ ] If the user edits `tiny_image_dataset` to vectorize the per-pixel loop (`out = arr * 2.0 - 1.0`), `equality.passed == true` and `delta_vs_prev_accepted.per_call_speedup_x > 1.5` (the loop is the dominant cost)
+- [ ] If the user edits `tiny_image_dataset` to change shapes (e.g. drop a channel), `equality.passed == false` and `first_diff_path` names the differing leaf
+- [ ] If `__getitem__` raises during measurement, output JSON has `equality.passed == false` and `summary` starts with `"raised "`
+- [ ] `delta_vs_prev_accepted` is computed against the most recent `measure-K.json` with `equality.passed == true`, falling back to `baseline.json` if none
+- [ ] Exit code is `0` on equality failure (not an error — this is normal flow); non-zero only on harness-level failures (e.g., baseline-dir missing)
+
+**Verify:**
+
+```bash
+# Reuse the baseline directory from Task 2's verify.
+BASELINE_DIR=/tmp/getitem-profile-test
+cd plugins/ml-research/skills/getitem-profiler
+
+# Case 1: unmodified factory → equality passes, speedup near 1.0
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py measure \
+    --factory tiny_image_dataset:make_dataset \
+    --baseline-dir $BASELINE_DIR && \
+python3 -c "
+import json, pathlib, glob
+files = sorted(glob.glob('$BASELINE_DIR/measure-*.json'))
+m = json.loads(pathlib.Path(files[-1]).read_text())
+assert m['equality']['passed'] is True, m
+sp = m['delta_vs_prev_accepted']['per_call_speedup_x']
+assert 0.85 < sp < 1.15, f'speedup unexpectedly far from 1.0: {sp}'
+print('OK unchanged')
+"
+
+# Case 2: vectorize the hotspot → equality passes, speedup > 1.5
+cp tests/fixtures/tiny_image_dataset.py /tmp/tiny_image_dataset.py.bak
+python3 -c "
+import pathlib
+p = pathlib.Path('tests/fixtures/tiny_image_dataset.py')
+src = p.read_text()
+new = src.replace(
+    '        out = np.empty_like(arr)\n        for i in range(self.side):\n            for j in range(self.side):\n                out[i, j] = arr[i, j] * 2.0 - 1.0\n',
+    '        out = arr * 2.0 - 1.0\n'
+)
+assert new != src, 'pattern not found — fixture text drift'
+p.write_text(new)
+"
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py measure \
+    --factory tiny_image_dataset:make_dataset \
+    --baseline-dir $BASELINE_DIR && \
+python3 -c "
+import json, pathlib, glob
+files = sorted(glob.glob('$BASELINE_DIR/measure-*.json'))
+m = json.loads(pathlib.Path(files[-1]).read_text())
+assert m['equality']['passed'] is True, m
+sp = m['delta_vs_prev_accepted']['per_call_speedup_x']
+assert sp > 1.5, f'expected speedup > 1.5, got {sp}'
+print('OK vectorized')
+"
+# Restore the fixture
+cp /tmp/tiny_image_dataset.py.bak tests/fixtures/tiny_image_dataset.py
+
+# Case 3: shape-changing edit → equality fails
+python3 -c "
+import pathlib
+p = pathlib.Path('tests/fixtures/tiny_image_dataset.py')
+src = p.read_text()
+# Drop a channel: 'permute(2, 0, 1).contiguous()' → '[:2].permute(2, 0, 1).contiguous()'  ←  wrong shape after permute, so simulate by slicing first dim of the np array
+new = src.replace(
+    '        img = torch.from_numpy(out).permute(2, 0, 1).contiguous()\n',
+    '        img = torch.from_numpy(out[:, :, :2]).permute(2, 0, 1).contiguous()\n'
+)
+assert new != src
+p.write_text(new)
+"
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py measure \
+    --factory tiny_image_dataset:make_dataset \
+    --baseline-dir $BASELINE_DIR && \
+python3 -c "
+import json, pathlib, glob
+files = sorted(glob.glob('$BASELINE_DIR/measure-*.json'))
+m = json.loads(pathlib.Path(files[-1]).read_text())
+assert m['equality']['passed'] is False, m
+assert m['equality'].get('first_diff_path'), m
+print('OK shape-change')
+"
+# Restore
+cp /tmp/tiny_image_dataset.py.bak tests/fixtures/tiny_image_dataset.py
+
+# Case 4: raise → equality fails with 'raised'
+python3 -c "
+import pathlib
+p = pathlib.Path('tests/fixtures/tiny_image_dataset.py')
+src = p.read_text()
+new = src.replace(
+    '    def __getitem__(self, idx: int) -> dict:\n',
+    '    def __getitem__(self, idx: int) -> dict:\n        raise RuntimeError(\"injected for testing\")\n'
+)
+assert new != src
+p.write_text(new)
+"
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py measure \
+    --factory tiny_image_dataset:make_dataset \
+    --baseline-dir $BASELINE_DIR && \
+python3 -c "
+import json, pathlib, glob
+files = sorted(glob.glob('$BASELINE_DIR/measure-*.json'))
+m = json.loads(pathlib.Path(files[-1]).read_text())
+assert m['equality']['passed'] is False, m
+assert m['equality']['summary'].startswith('raised '), m
+print('OK raised')
+"
+# Restore
+cp /tmp/tiny_image_dataset.py.bak tests/fixtures/tiny_image_dataset.py
+```
+
+Expected: `OK unchanged`, `OK vectorized`, `OK shape-change`, `OK raised`.
+
+**Steps:**
+
+- [ ] **Step 1: Add `cmd_measure` and helpers**
+
+Add to `profile_getitem.py`:
+
+```python
+def _next_measure_path(out_dir: Path) -> Path:
+    n = 1
+    while (out_dir / f"measure-{n}.json").exists():
+        n += 1
+    return out_dir / f"measure-{n}.json"
+
+
+def _latest_accepted_measure(out_dir: Path) -> dict | None:
+    """Return the most recent measure-N.json with equality.passed == true, or None."""
+    files = sorted(out_dir.glob("measure-*.json"),
+                   key=lambda p: int(p.stem.split("-")[1]),
+                   reverse=True)
+    for f in files:
+        try:
+            data = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("equality", {}).get("passed") is True:
+            return data
+    return None
+
+
+def _compute_delta(curr_mean: float, curr_bench_bps: float,
+                   ref_mean: float, ref_bench_bps: float) -> dict:
+    return {
+        "per_call_speedup_x": (ref_mean / curr_mean) if curr_mean > 0 else 0.0,
+        "dataloader_speedup_x": (curr_bench_bps / ref_bench_bps) if ref_bench_bps > 0 else 0.0,
+    }
+
+
+def cmd_measure(args) -> int:
+    baseline_dir = Path(args.baseline_dir)
+    baseline_path = baseline_dir / "baseline.json"
+    if not baseline_path.exists():
+        print(f"baseline.json not found at {baseline_path}", file=sys.stderr)
+        return 2
+    baseline = json.loads(baseline_path.read_text())
+    if baseline.get("equality_mode") == "non_deterministic":
+        print("baseline is non-deterministic; cannot measure", file=sys.stderr)
+        return 2
+
+    factory = load_factory(args.factory)
+    dataset = factory()
+
+    indices = baseline["indices"]
+    seed_base = baseline["seed_base"]
+
+    measure_path = _next_measure_path(baseline_dir)
+
+    # Equality check (fail-fast: bail at first mismatch or exception).
+    per_call_times: list[float] = []
+    for i in indices:
+        try:
+            seed_all(seed_base + i)
+            t0 = time.perf_counter()
+            out = dataset[i]
+            dt = time.perf_counter() - t0
+        except Exception as e:  # noqa: BLE001
+            payload = {
+                "equality": {
+                    "passed": False,
+                    "first_diff_path": f"outputs[{i}]",
+                    "summary": f"raised {type(e).__name__}: {e}",
+                },
+            }
+            measure_path.write_text(json.dumps(payload, indent=2))
+            return 0
+        with open(baseline_dir / "baseline" / f"{i}.pkl", "rb") as f:
+            cached = pickle.load(f)
+        ok, diff_path, summary = deep_equal(out, cached, _path=f"outputs[{i}]")
+        if not ok:
+            payload = {
+                "equality": {"passed": False, "first_diff_path": diff_path, "summary": summary},
+            }
+            measure_path.write_text(json.dumps(payload, indent=2))
+            return 0
+        per_call_times.append(dt)
+
+    # Equality passed → re-profile + bench.
+    line_stats = run_line_profiler(dataset, indices, seed_base, args.profile_scope)
+
+    bench_dataset = factory()
+    try:
+        bench = run_dataloader_bench(
+            bench_dataset, args.num_workers, args.batch_size, args.bench_batches
+        )
+    except Exception as e:  # noqa: BLE001
+        payload = {
+            "equality": {
+                "passed": False,
+                "first_diff_path": "<dataloader>",
+                "summary": f"dataloader bench raised {type(e).__name__}: {e}",
+            },
+        }
+        measure_path.write_text(json.dumps(payload, indent=2))
+        return 0
+
+    mean_per_call = sum(per_call_times) / len(per_call_times)
+    baseline_mean = baseline["per_call_wall_time_s"]["mean"]
+    baseline_bps = baseline["dataloader_bench"]["batches_per_sec"]
+
+    prev = _latest_accepted_measure(baseline_dir)
+    if prev:
+        prev_mean = prev["per_call_wall_time_s"]["mean"]
+        prev_bps = prev["dataloader_bench"]["batches_per_sec"]
+    else:
+        prev_mean = baseline_mean
+        prev_bps = baseline_bps
+
+    payload = {
+        "equality": {"passed": True},
+        "per_call_wall_time_s": {"mean": mean_per_call, "indices": per_call_times},
+        "delta_vs_baseline": _compute_delta(mean_per_call, bench["batches_per_sec"],
+                                            baseline_mean, baseline_bps),
+        "delta_vs_prev_accepted": _compute_delta(mean_per_call, bench["batches_per_sec"],
+                                                 prev_mean, prev_bps),
+        "line_stats": line_stats,
+        "dataloader_bench": bench,
+    }
+    measure_path.write_text(json.dumps(payload, indent=2))
+    return 0
+```
+
+- [ ] **Step 2: Wire up the `measure` argparse subcommand**
+
+Replace the stub `p_m` block in `main()` with:
+
+```python
+    p_m = sub.add_parser("measure")
+    p_m.add_argument("--factory", required=True)
+    p_m.add_argument("--baseline-dir", required=True)
+    p_m.add_argument("--profile-scope", choices=["local", "package"], default="local")
+    p_m.add_argument("--num-workers", type=int, default=4)
+    p_m.add_argument("--batch-size", type=int, default=16)
+    p_m.add_argument("--bench-batches", type=int, default=50)
+    p_m.set_defaults(func=cmd_measure)
+```
+
+- [ ] **Step 3: Run the verify cases from the Verify section**
+
+This is four cases — run each in order and check for the four `OK ...` outputs.
+
+If a step fails: the most likely culprit is module re-importation. `cmd_measure` calls `load_factory` which calls `importlib.import_module`. After the test edits the fixture file, the new `measure` invocation is a fresh process, so the import is fresh. (No `importlib.reload` needed.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+git commit -m "Implement measure subcommand for getitem-profiler harness"
+```
+
+---
+
+### Task 4: Write the SKILL.md orchestration prompt
+
+**Goal:** Replace the Task 0 frontmatter stub with the full orchestration prompt that drives the greedy edit loop. This is the agent-facing artifact.
+
+**Files:**
+
+- Modify: `plugins/ml-research/skills/getitem-profiler/SKILL.md`
+
+**Acceptance Criteria:**
+
+- [ ] Frontmatter has `name: getitem-profiler` and a `description:` matching spec § "SKILL.md → frontmatter" triggering language
+- [ ] Body has these sections in order: **Identity**, **Setup (once per session)**, **The greedy loop**, **Hard rules**, **Caveat layer**, **Termination summary**
+- [ ] The greedy loop section names the three termination conditions (line < 5%, 3 consecutive failures, user interrupt)
+- [ ] The hard rules section names: edit-scope limit, no mutable cross-call state, no validation-set edits, one edit per commit, branch-only edits
+- [ ] The caveat layer matches the wording in spec § "Caveat layer"
+- [ ] The greedy-loop step "Decision" uses `delta_vs_prev_accepted.per_call_speedup_x` (not `delta_vs_baseline`) and the 1.05× threshold
+- [ ] Total length ~150–200 lines (target from spec § "Files → Plugin-shipped")
+
+**Verify:**
+
+```bash
+python3 -c "
+import pathlib, re
+p = pathlib.Path('plugins/ml-research/skills/getitem-profiler/SKILL.md')
+text = p.read_text()
+# Frontmatter
+assert text.startswith('---\n'), 'missing frontmatter'
+fm_end = text.index('\n---\n', 4)
+fm = text[4:fm_end]
+assert 'name: getitem-profiler' in fm, fm
+assert 'description:' in fm, fm
+body = text[fm_end + 5:]
+# Required sections
+for hdr in ['## Identity', '## Setup', '## The greedy loop', '## Hard rules', '## Caveat layer', '## Termination summary']:
+    assert hdr in body, f'missing section: {hdr}'
+# Decision rule references the right delta
+assert 'delta_vs_prev_accepted' in body, 'decision rule must reference delta_vs_prev_accepted'
+assert '1.05' in body, 'threshold missing'
+# Termination conditions
+assert '5%' in body and 'consecutive' in body and 'interrupt' in body, 'termination conditions incomplete'
+# Hard rules
+for rule in ['cross-call state', 'validation', 'one edit', 'side branch']:
+    assert rule in body, f'hard rule missing: {rule}'
+# Length
+n_lines = text.count('\n')
+assert 100 < n_lines < 280, f'SKILL.md length {n_lines} outside target range'
+print('OK')
+"
+```
+
+Expected: `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Replace `SKILL.md` with the full prompt**
+
+The body assembles content from spec sections in this order. Cross-reference the spec's wording where exact phrasing matters (the caveat layer is verbatim).
+
+```markdown
+---
+name: getitem-profiler
+description: Profile Dataset.__getitem__ with line_profiler and greedily optimize the slowest line on a side branch, gated by output equality and a per-call speedup threshold. Use when the user says "__getitem__ is slow", "profile my dataset", "speed up my dataloader", "find the bottleneck in my dataset class", or supplies a factory function and asks for optimization.
+---
+
+## Identity
+
+Greedy line-level optimizer for `Dataset.__getitem__`. The harness at `scripts/profile_getitem.py` is the source of truth for measurement — never guess at timings, never decide acceptance from memory. After every edit, re-invoke the harness and read its JSON.
+
+You do not read the user's full dataset module up front. You read just enough surrounding code per edit to understand the line being targeted. The harness handles all instrumentation, seeding, equality checks, and benchmarking.
+
+## Setup (once per session)
+
+Confirm with the user:
+
+1. **Factory path** — `pkg.mod:make_dataset` returning a ready dataset instance. Document the one-liner template if the user doesn't have one yet:
+   ```python
+   def make_dataset():
+       from mypkg.dataset import MyDataset
+       return MyDataset(root="/path", split="train", transform=...)
+   ```
+2. **`--num-indices`** — default 8.
+3. **`--profile-scope`** — default `local` (only the dataset class + its defining module). Use `package` if the user's transforms / IO helpers live in sibling modules of the same top-level package.
+4. **`--num-workers`** for the DataLoader bench — default 4.
+
+Then:
+
+1. Add `.getitem-profile/` to `.gitignore` if not already present.
+2. Create the side branch: `git checkout -b getitem-profile/<dataset-slug>-<YYYYMMDD-HHMM>` off the user's current `HEAD`.
+3. Run `python scripts/profile_getitem.py baseline --factory <factory> --num-indices <N> --profile-scope <scope> --num-workers <W> --out-dir .getitem-profile/`.
+4. Read `.getitem-profile/baseline.json`.
+5. Bail if either:
+   - `equality_mode == "non_deterministic"` — surface the `first_diff_path` to the user, name the leaf that differs, offer two paths: (a) supply `--equality-fn pkg.mod:fn` that tolerates the non-determinism, (b) bail. Never silently fall back to tolerance.
+   - `reliable_line_stats == false` — tell the user the dataset is already fast (mean per-call < ~1 ms); wins here would be in the noise.
+6. Otherwise, show the user a brief table of the top-5 slowest lines + the baseline DataLoader throughput so they know the starting point.
+
+Surface the **caveat layer** (verbatim, see below) at session start.
+
+## The greedy loop
+
+State you maintain across iterations:
+- `failed_lines: set[(file, line)]` — lines we've already tried and failed on.
+- `consecutive_failures: int` — reset to 0 on accept.
+- `accepted_commits: list[str]` — for the final summary.
+
+Per iteration:
+
+1. **Pick the next-slowest line** from the most recent JSON's `line_stats` (sorted by `pct` descending) that is not in `failed_lines` and whose `file` lives inside the dataset module's directory or sibling modules in the same top-level package. If the slowest line is outside this scope (a `--profile-scope=package` artifact, e.g., a third-party helper), note it and skip to the next.
+2. **Termination checks:**
+   - If the targeted line's `pct` < 5% → stop (diminishing returns).
+   - If `consecutive_failures >= 3` → stop.
+   - If the user has interrupted → stop.
+3. **Read just enough**: the function the line is in, ~20 surrounding lines, and any helper it calls. Don't read the whole module.
+4. **Propose one concrete edit.** Common-win categories (vocabulary, not a checklist):
+   - vectorize a Python loop into numpy/torch ops
+   - replace PIL with `cv2` or `torchvision.io` for decode
+   - cache an expensive constant in `__init__`
+   - replace per-call file open with mmap or a pre-indexed handle
+   - construct tensors on the right dtype/device once
+   - remove a redundant `.copy()` or `.contiguous()`
+   - pre-tokenize / pre-resize at dataset init time
+5. **Apply the edit** (single Edit tool call). Do NOT commit yet.
+6. **Run** `python scripts/profile_getitem.py measure --factory <factory> --baseline-dir .getitem-profile/ --profile-scope <scope> --num-workers <W>`. Read the new `measure-N.json`.
+7. **Decision** — use `delta_vs_prev_accepted.per_call_speedup_x`:
+   - **Equality failed** → `git restore <changed_file>`. Add the line to `failed_lines`. `consecutive_failures += 1`.
+   - **Equality passed but speedup < 1.05×** → same `git restore` path. Smaller wins are noise.
+   - **Equality passed and speedup ≥ 1.05×** → `git add <file>` + `git commit -m "perf(<file>:<line>): <one-line summary>"`. Reset `consecutive_failures = 0`. Append an entry to `.getitem-profile/session.md`.
+8. Loop.
+
+After each accepted edit, append to `.getitem-profile/session.md`:
+
+```markdown
+## Edit <N> — <one-line summary>
+- target: <file>:<line> (was <pct>% of __getitem__)
+- per-call: <before> ms → <after> ms (<delta_vs_prev_accepted.per_call_speedup_x>x)
+- dataloader: <before> batches/s → <after> batches/s (<delta_vs_prev_accepted.dataloader_speedup_x>x)
+- commit: <short SHA>
+```
+
+Append rejected attempts under a separate `## Rejected` section: target line + brief reason.
+
+## Hard rules
+
+- **Edit-scope limit.** Edit only inside the dataset class / its defining module / sibling modules in the same top-level package, scoped by `--profile-scope`. Never broaden silently. If the slowest line is outside scope, skip it.
+- **No mutable cross-call state.** Caching `__getitem__` results across calls is forbidden. The per-index equality check would pass while DataLoader workers (which fork the dataset) silently diverge.
+- **No validation-set edits.** Don't touch validation code or any code path outside `__getitem__`'s call graph.
+- **One edit per commit.** No bundling — defeats per-line attribution. The harness's accept/reject decision is per-edit; mixing two changes in one commit makes attribution impossible.
+- **Side branch only.** Never touch `main` or the user's prior branch. The skill never deletes the side branch — the user merges or discards.
+
+## Caveat layer
+
+Surface this at session start AND in the final summary:
+
+> Per-call timings come from in-process measurement; under a real DataLoader, fixed costs (worker startup, IPC, fork-time imports) won't show up here. The DataLoader micro-benchmark gives a sanity check, but wins below ~50 µs per call may not translate. Wins should generally hold across distributed ranks since each rank's workers are independent.
+
+## Termination summary
+
+When the loop terminates (any condition), print:
+
+- starting per-call wall time (from `baseline.json`)
+- ending per-call wall time (from the most recent accepted measure)
+- total speedup (`delta_vs_baseline.per_call_speedup_x`)
+- DataLoader throughput before/after
+- list of accepted commits with one-line summaries
+- list of rejected target lines with brief reasons
+- the caveat layer (repeated)
+- the branch name; instruct the user to review and merge/discard
+
+## Resumption
+
+If a session is interrupted and the user re-invokes the skill: detect an existing `.getitem-profile/` dir + `getitem-profile/...` branch; read `session.md` to recover `failed_lines` and `accepted_commits`; resume the loop without re-baselining. The cached outputs in `.getitem-profile/baseline/` and `baseline.json` remain authoritative.
+```
+
+- [ ] **Step 2: Run the verify command**
+
+Expected: `OK`
+
+If the length check fails: trim or expand sections to bring `n_lines` into the target range. The body is meant to be ~150–200 lines (the verify allows up to 280 to give some slack for header overhead).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ml-research/skills/getitem-profiler/SKILL.md
+git commit -m "Write getitem-profiler SKILL.md orchestration prompt"
+```
+
+---
+
+### Task 5: End-to-end smoke test
+
+**Goal:** Exercise the skill+harness combination on the synthetic fixture in a way that mimics what the skill would actually do — baseline, edit, measure, commit-or-revert. This is the final integration check before the skill is usable.
+
+**Files:**
+
+- No source changes. May create / clean up `/tmp/getitem-smoke/` during the test.
+
+**Acceptance Criteria:**
+
+- [ ] Running the full sequence (baseline → vectorize the loop → measure → confirm acceptance threshold met → restore fixture) completes with no errors
+- [ ] `delta_vs_prev_accepted.per_call_speedup_x` for the vectorized edit is ≥ 1.5 (the loop is the dominant cost; vectorizing is a clear win)
+- [ ] After restoring the fixture, the original baseline still applies (no leftover state)
+
+**Verify:**
+
+```bash
+set -euo pipefail
+cd plugins/ml-research/skills/getitem-profiler
+
+OUT=/tmp/getitem-smoke
+rm -rf "$OUT"
+
+# 1. Baseline.
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py baseline \
+    --factory tiny_image_dataset:make_dataset \
+    --num-indices 4 --num-workers 2 --bench-batches 10 \
+    --out-dir "$OUT"
+python3 -c "
+import json, pathlib
+b = json.loads(pathlib.Path('$OUT/baseline.json').read_text())
+assert b['equality_mode'] == 'strict'
+assert b['reliable_line_stats'] is True
+print('baseline OK, mean per-call =', b['per_call_wall_time_s']['mean'])
+"
+
+# 2. Apply the obvious optimization (vectorize the per-pixel loop).
+cp tests/fixtures/tiny_image_dataset.py /tmp/tiny_image_dataset.py.bak
+python3 -c "
+import pathlib
+p = pathlib.Path('tests/fixtures/tiny_image_dataset.py')
+src = p.read_text()
+new = src.replace(
+    '        out = np.empty_like(arr)\n        for i in range(self.side):\n            for j in range(self.side):\n                out[i, j] = arr[i, j] * 2.0 - 1.0\n',
+    '        out = arr * 2.0 - 1.0\n'
+)
+assert new != src
+p.write_text(new)
+"
+
+# 3. Measure.
+PYTHONPATH=tests/fixtures python3 scripts/profile_getitem.py measure \
+    --factory tiny_image_dataset:make_dataset \
+    --baseline-dir "$OUT" --num-workers 2 --bench-batches 10
+python3 -c "
+import json, pathlib, glob
+files = sorted(glob.glob('$OUT/measure-*.json'))
+m = json.loads(pathlib.Path(files[-1]).read_text())
+assert m['equality']['passed'] is True
+sp = m['delta_vs_prev_accepted']['per_call_speedup_x']
+assert sp >= 1.5, f'expected speedup >= 1.5, got {sp}'
+print('measure OK, speedup =', sp)
+"
+
+# 4. Restore + confirm clean state.
+cp /tmp/tiny_image_dataset.py.bak tests/fixtures/tiny_image_dataset.py
+rm /tmp/tiny_image_dataset.py.bak
+rm -rf "$OUT"
+
+echo "SMOKE OK"
+```
+
+Expected last line: `SMOKE OK`.
+
+**Steps:**
+
+- [ ] **Step 1: Run the verify block end-to-end**
+
+If anything fails, fix the issue in the relevant earlier task (don't paper over it here). The smoke test is the gate — failures here mean an upstream task didn't actually work.
+
+- [ ] **Step 2: Commit (if any fixes were needed)**
+
+If the smoke test passed first try, no commit needed. If you had to fix a bug, commit the fix:
+
+```bash
+git add -A plugins/ml-research/skills/getitem-profiler/
+git commit -m "Fix smoke-test failure in getitem-profiler"
+```
+
+- [ ] **Step 3: Final review**
+
+Read `plugins/ml-research/skills/getitem-profiler/SKILL.md` end-to-end one more time. Check that nothing references files or arguments that don't exist (`scripts/profile_getitem.py` exists; `--factory`, `--num-indices`, `--profile-scope`, `--num-workers`, `--out-dir`, `--baseline-dir` all match what `argparse` accepts).
+
+Mark this task complete only if the SKILL.md ↔ argparse surface matches.
+
+---
+
+## Self-review notes
+
+Cross-checked against the spec:
+
+- Spec § "Architecture" → Task 0 + the file-structure section above.
+- Spec § "Data model → baseline.json / measure-N.json" → Tasks 2 + 3 produce the exact JSON shapes.
+- Spec § "Phase 0: Setup" → SKILL.md `## Setup` section in Task 4.
+- Spec § "Phase 1: Greedy loop" → SKILL.md `## The greedy loop` section in Task 4.
+- Spec § "Helper script (`profile_getitem.py`)" → Tasks 2 + 3.
+- Spec § "Edge cases" → covered:
+  - Non-deterministic dataset → Task 2 acceptance + verify (uses `nondeterministic_dataset` fixture).
+  - Too-fast dataset → Task 2 (`reliable_line_stats: false` heuristic, threshold 1 ms).
+  - Edit raises → Task 3 case 4.
+  - DataLoader bench fails → Task 3 has try/except around `run_dataloader_bench`.
+  - No-op edit → Task 3 verify case 1 demonstrates speedup ≈ 1.0; SKILL.md's 1.05× threshold rejects it.
+  - Tied slowest lines → `line_stats` is sorted descending, ties resolve by Python's stable sort (file order); SKILL.md's "next-slowest line" picker is deterministic given the JSON.
+  - Out-of-scope subfunction → SKILL.md "Edit-scope limit" hard rule covers it; Task 4 acceptance includes the rule.
+  - Resumption → SKILL.md `## Resumption` section.
+- Spec § "Hard rules" → SKILL.md `## Hard rules` section, Task 4 acceptance enumerates each.
+- Spec § "Caveat layer" → SKILL.md `## Caveat layer` section, verbatim.
+- Spec § "Out of scope" → not implemented (correct).
+
+No type/method-name drift across tasks: `deep_equal`, `load_factory`, `seed_all`, `call_one`, `run_line_profiler`, `run_dataloader_bench`, `cmd_baseline`, `cmd_measure` are defined once and referenced consistently.

--- a/docs/superpowers/plans/2026-04-26-getitem-profiler.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-26-getitem-profiler.md.tasks.json
@@ -1,0 +1,47 @@
+{
+  "planPath": "docs/superpowers/plans/2026-04-26-getitem-profiler.md",
+  "tasks": [
+    {
+      "id": 0,
+      "subject": "Task 0: Scaffold skill directory and synthetic test fixtures",
+      "status": "pending",
+      "description": "**Goal:** Lay down the skill directory + two synthetic test datasets the harness can be exercised against.\n\n**Files:**\n- Create: plugins/ml-research/skills/getitem-profiler/SKILL.md (frontmatter stub)\n- Create: plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py (empty main)\n- Create: plugins/ml-research/skills/getitem-profiler/tests/fixtures/tiny_image_dataset.py\n- Create: plugins/ml-research/skills/getitem-profiler/tests/fixtures/nondeterministic_dataset.py\n- Create: plugins/ml-research/skills/getitem-profiler/tests/fixtures/README.md\n\n**Acceptance Criteria:**\n- Skill loads (frontmatter parses, name=getitem-profiler)\n- profile_getitem.py prints usage with no args\n- tiny_image_dataset.make_dataset() is deterministic under seed and >1ms per call\n- nondeterministic_dataset.make_dataset() differs across two seeded calls\n\n**Verify:** see Task 0 in plan.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/getitem-profiler/SKILL.md\", \"plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\", \"plugins/ml-research/skills/getitem-profiler/tests/fixtures/tiny_image_dataset.py\", \"plugins/ml-research/skills/getitem-profiler/tests/fixtures/nondeterministic_dataset.py\", \"plugins/ml-research/skills/getitem-profiler/tests/fixtures/README.md\"], \"verifyCommand\": \"see plan Task 0 verify block\", \"acceptanceCriteria\": [\"skill loads\", \"profile_getitem.py prints usage\", \"tiny_image_dataset deterministic and slow\", \"nondeterministic_dataset non-deterministic\"]}\n```"
+    },
+    {
+      "id": 1,
+      "subject": "Task 1: Implement equality walker (deep_equal)",
+      "status": "pending",
+      "blockedBy": [0],
+      "description": "**Goal:** Implement deep_equal(a, b) in profile_getitem.py — recursive walker over dicts/lists/tuples/tensors/arrays/PIL/primitives, returns (passed, first_diff_path, summary).\n\n**Files:**\n- Modify: plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\n\n**Acceptance Criteria:**\n- Equal cases return (True, None, None) for tensors, arrays, dicts, lists, tuples, PIL Images, primitives\n- Unequal cases return correct first_diff_path (e.g. 'outputs.a', 'outputs[1]')\n- Different dtypes count as unequal\n- PIL equality compares tobytes/size/mode\n- Unknown leaf types fall back to == with exception capture\n\n**Verify:** see Task 1 verify block — tests deep_equal on all leaf types directly.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\"], \"verifyCommand\": \"see plan Task 1 verify block\", \"acceptanceCriteria\": [\"equal cases pass\", \"unequal cases name correct path\", \"dtype mismatch fails\", \"PIL bytewise compare\"]}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: Implement baseline subcommand end-to-end",
+      "status": "pending",
+      "blockedBy": [1],
+      "description": "**Goal:** Implement profile_getitem.py baseline — factory loading, RNG seeding, output cache, line_profiler integration, dataloader bench, determinism self-check, fast-dataset heuristic, JSON output.\n\n**Files:**\n- Modify: plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\n\n**Acceptance Criteria:**\n- baseline.json has all required keys\n- On tiny_image_dataset: equality_mode=strict, reliable_line_stats=true, top line_stats entry is the per-pixel loop with pct>50\n- On nondeterministic_dataset: equality_mode=non_deterministic, first_diff_path set, exit 0\n- argparse defaults: --num-indices 8, --num-workers 4, --bench-batches 50, --profile-scope local, --out-dir .getitem-profile\n\n**Verify:** see Task 2 verify block — runs baseline on both fixtures.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\"], \"verifyCommand\": \"see plan Task 2 verify block\", \"acceptanceCriteria\": [\"baseline.json shape correct\", \"strict mode on deterministic dataset\", \"non_deterministic mode on nondet dataset\", \"hotspot line ranked >50%\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: Implement measure subcommand end-to-end",
+      "status": "pending",
+      "blockedBy": [2],
+      "description": "**Goal:** Implement profile_getitem.py measure — equality-check vs cached outputs, re-profile, compute delta_vs_baseline and delta_vs_prev_accepted, JSON output. Equality failures + raised exceptions + dataloader-bench failures all surface through equality.passed=false.\n\n**Files:**\n- Modify: plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\n\n**Acceptance Criteria:**\n- Unmodified factory: equality.passed=true, speedup ~1.0\n- Vectorized hotspot: equality.passed=true, speedup>1.5\n- Shape-changing edit: equality.passed=false with first_diff_path\n- Raising __getitem__: equality.passed=false with summary starting 'raised '\n- delta_vs_prev_accepted falls back to baseline if no prior accepted measure\n- Exit 0 on equality failure (it's normal flow)\n\n**Verify:** see Task 3 verify block — exercises 4 cases.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py\"], \"verifyCommand\": \"see plan Task 3 verify block\", \"acceptanceCriteria\": [\"unchanged: pass + speedup ~1\", \"vectorized: pass + speedup>1.5\", \"shape-change: fail with path\", \"raise: fail with 'raised'\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: Write SKILL.md orchestration prompt",
+      "status": "pending",
+      "blockedBy": [3],
+      "description": "**Goal:** Replace SKILL.md frontmatter stub with the full orchestration prompt — Identity, Setup, Greedy loop, Hard rules, Caveat layer, Termination summary, Resumption.\n\n**Files:**\n- Modify: plugins/ml-research/skills/getitem-profiler/SKILL.md\n\n**Acceptance Criteria:**\n- All required sections present\n- Decision rule references delta_vs_prev_accepted (not delta_vs_baseline) and 1.05x threshold\n- Three termination conditions named (5%, 3 consecutive failures, user interrupt)\n- All five hard rules present (scope, no cross-call state, no validation edits, one-edit-per-commit, branch-only)\n- Caveat layer matches spec verbatim\n- Length ~150-200 lines\n\n**Verify:** see Task 4 verify block — structural check via grep/python.\n\n```json:metadata\n{\"files\": [\"plugins/ml-research/skills/getitem-profiler/SKILL.md\"], \"verifyCommand\": \"see plan Task 4 verify block\", \"acceptanceCriteria\": [\"all sections present\", \"decision rule uses delta_vs_prev_accepted\", \"all hard rules present\", \"caveat layer verbatim\", \"length in range\"]}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: End-to-end smoke test",
+      "status": "pending",
+      "blockedBy": [4],
+      "description": "**Goal:** Exercise skill+harness on synthetic fixture: baseline → vectorize → measure → confirm acceptance → restore. Final integration check.\n\n**Files:**\n- No source changes. Uses /tmp/getitem-smoke as scratch.\n\n**Acceptance Criteria:**\n- Full sequence completes with no errors\n- Vectorization speedup >= 1.5\n- Original fixture restored, no leftover state\n- SKILL.md ↔ argparse surface matches (final review)\n\n**Verify:** see Task 5 verify block — full e2e bash script.\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"see plan Task 5 verify block\", \"acceptanceCriteria\": [\"full sequence completes\", \"vectorization speedup>=1.5\", \"clean state after\", \"SKILL.md/argparse surface matches\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-04-26"
+}

--- a/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
@@ -1,0 +1,643 @@
+# Autoresearch skill — ground-up redesign
+
+Date: 2026-04-24
+Status: spec approved, plan not yet written
+
+## Motivation
+
+The current `ml-research:autoresearch` skill iterates on an ML model through rapid small-scale experiments. It works, but the architecture has three latent problems as a campaign accumulates experiments:
+
+1. **Context rot.** Everything — ideas, narrative log, structured metrics — is in a handful of markdown/CSV files that get loaded whole at every turn. After dozens of experiments, the log alone exceeds useful context.
+2. **Weak auditability at granularity.** A single unbounded `autoresearch_log.md` commingles many experiments' narratives; searching for one requires loading the whole file.
+3. **No use of Claude-native context-management primitives.** The design predates the design norms behind progressive disclosure, subagent delegation, auto-memory, and structured tool notifications.
+
+This redesign targets those three, under the constraints:
+
+- **Runs inside Claude Code** (a skill, not a standalone SDK harness). Uses Claude Code-native primitives: the `Agent` tool (subagents), `TaskCreate`/`TaskList`, `Monitor`, `WebSearch`, the auto-memory directory, and the harness's built-in compaction.
+- **Auditability via trunk-based development.** Every experiment's code is preserved on its own git branch forever; accepted experiments squash-merge onto the campaign trunk.
+- **Fully autonomous after Phase 0.** Only user interaction is at one-time setup and when the user explicitly addresses the agent. Every transient infra failure, ambiguous result, and exhausted idea queue is handled by the agent itself.
+- **Multi-campaign isolation.** Multiple autoresearch loops can run in parallel per project (different models, different config profiles) without state collision.
+
+## Architecture
+
+Three actors operate against a per-campaign state store:
+
+```
+Main agent (ml-research:autoresearch skill, thin orchestrator)
+    │
+    ├─── dispatches ──► Ideator subagent     (one idea with citations)
+    ├─── dispatches ──► Experimenter subagent (one experiment end-to-end)
+    └─── dispatches ──► Reviewer subagent     (periodic insights synthesis)
+
+Per-campaign state store (git-tracked worktree):
+    ../autoresearch-<project_name>/
+    └── autoresearch/
+        ├── config.json         # user-authoritative
+        ├── ideas.md            # user-input buffer (FIFO)
+        ├── insights.md         # synthesized cross-experiment patterns
+        ├── results.csv         # structured metrics, one row/experiment
+        └── experiments/
+            ├── 001-baseline.md
+            └── NNN-<slug>.md   # frontmatter + narrative
+```
+
+### Division of responsibility
+
+| Actor | Scope | Reads | Writes |
+|---|---|---|---|
+| **Main agent** | Phase 0 setup (interactive); Phase 1 loop dispatch; git operations | `config.json`, `ideas.md`, `insights.md`, `results.csv`, experiment file frontmatters (scan-only) | Trunk: tracking files, experiment files, CSV rows, branch merges |
+| **Ideator** | Generate exactly one experiment idea with citations | Same as main agent + JIT-read of past experiment files and code, WebSearch | Nothing to disk; returns structured object |
+| **Experimenter** | Implement + launch + monitor + analyze one experiment, with internal debug loop | Same + `relevant_files` reads | Experiment branch only; code files matching `relevant_files.editable` |
+| **Reviewer** | Synthesize insights from last 5 succeeded experiments | Recent experiment files, `insights.md`, CSV | Nothing to disk; returns structured insights delta |
+
+### Context management strategy
+
+Progressive disclosure is the core principle:
+
+- **Main agent context stays flat** across campaign lifetime. Reads ≤10 KB of small, bounded tracking files per iteration. Never reads experiment narratives in bulk. Never holds subagent tool-call noise.
+- **Subagent contexts die on return.** Each subagent performs whatever deep reading/tool use it needs, condenses to its structured return, and evaporates. The main agent sees only the return.
+- **`insights.md` is the auto-synthesized long-term memory** (produced by Reviewer), bounded to ~50 lines. It acts as the main agent's compressed knowledge of the campaign.
+
+The auto-memory directory (`~/.claude/projects/<proj>/memory/`) stays reserved for genuine cross-session/cross-campaign user+project context — it is *not* used for campaign-scoped research artifacts, since per-project memory would pollute every non-autoresearch session with campaign-specific files.
+
+## Data model
+
+### `autoresearch/config.json`
+
+User-authoritative, written once at Phase 0 setup, read by the main agent at every iteration. Strict schema (JSON, no comments):
+
+```json
+{
+  "project_name": "my-project",
+  "relevant_files": {
+    "read_only": ["config/conf.yaml", "src/data/**/*.py"],
+    "editable":  ["src/models/**/*.py", "src/losses/*.py"]
+  },
+  "entrypoints": {
+    "count_params":      { "command": "uv run python scripts/count_params.py" },
+    "launch_experiment": {
+      "command": "scripts/launch.sh",
+      "environment": "slurm"
+    }
+  },
+  "debug_cap": 3,
+  "constraints": [
+    "no change to random seed, step count, validation dataset, validation logic, or validation metrics",
+    "parameter count must be <= baseline * 1.05",
+    "no change to core dependencies / package versions"
+  ],
+  "theme_priorities": {
+    "high":   ["data_augmentation", "training_objective"],
+    "medium": ["architecture"],
+    "low":    ["optimizer"]
+  },
+  "prior_findings": [
+    "LR sweep: 3e-4 > 1e-4",
+    "Dropout didn't help",
+    "Cosine > constant"
+  ]
+}
+```
+
+Notes on semantics:
+
+- **`relevant_files`** is a hard safety rail for Experimenter. Shell-style globs (`**`, `*`, `?`). Subagents may only *edit* files matching `editable`; they may *read* files matching `read_only`; files outside both lists are implicitly off-limits.
+- **`entrypoints`** — pluggable user-provided commands. Contract for each is documented in SKILL.md (not duplicated per-campaign). `count_params.command` must print JSON with keys `trainable_params`, `total_params` to stdout. `launch_experiment.command` must submit a job, print its job ID to stdout, and accept training overrides as positional args.
+- **`environment`** is a free-form hint string (`"slurm"`, `"local"`, `"k8s"`, `"ray"`, …) that tells the Experimenter which env-specific skill (if any) to invoke for monitoring.
+- **`debug_cap`** caps the Experimenter's internal retry loop. Default 3. Counts total attempts including the first launch.
+- **`constraints`** is a flat list of free-text rules. Phase 0 seeds skill-default constraints; user can add/remove.
+- **`theme_priorities`** ranks themes. Skill-default theme list: `optimizer, initialization, data_augmentation, architecture, regularization, training_objective, tokenization, schedule`. The `training_objective` theme refers to the *training* loss / objective function; the validation metric is frozen by constraint and can never be a theme target.
+
+### `autoresearch/experiments/NNN-<slug>.md`
+
+One file per experiment. Frontmatter (required) + free-form markdown body (Experimenter-authored):
+
+```yaml
+---
+id: 42
+title: GELU in FFN
+date: 2026-04-24
+job_status: pending          # pending | succeeded | crashed
+result_status: null          # null | accepted | rejected | inconclusive
+theme: architecture
+tags: [activation, ffn]
+attempts: 1
+parent: 37                   # optional — experiment ID this builds on
+sources:                     # from the originating Ideator idea
+  - url: https://arxiv.org/abs/2301.12345
+    note: proposes GELU-like activation
+  - ref: insights.md#activations-underexplored
+    note: from insight synthesis
+---
+
+## Change
+<what was modified and why>
+
+## Training dynamics
+<convergence, stability, anomalies — per-attempt if multiple>
+
+## Analysis
+<why it worked/didn't; insights for future>
+
+## Complexity
+<lines changed; conceptual complexity; worth the improvement?>
+
+## Attempts log
+- attempt 1 (job 12345): OOM on batch 300 — retry with reduced batch
+- attempt 2 (job 12346): completed, final val loss 2.41
+```
+
+The "Attempts log" section appears only when `attempts > 1`.
+
+**Two-axis status:**
+
+- `job_status ∈ {pending, succeeded, crashed}` — did the job run to completion?
+- `result_status ∈ {null, accepted, rejected, inconclusive}` — is the measured outcome worth merging?
+
+Orthogonality rule: `result_status` is non-null only when `job_status: succeeded`. A crashed experiment never gets a result evaluation.
+
+### `autoresearch/results.csv`
+
+Structured-only (no freeform text, no duplication with frontmatter):
+
+```
+experiment_id,branch,commit,job_id,wandb_url,trainable_params,total_params,final_train_loss,final_val_loss
+```
+
+One row per `job_status: succeeded` experiment. Crashed experiments get no CSV row — their identity is preserved in the experiment file + git branch.
+
+### `autoresearch/ideas.md`
+
+**User-input buffer only** (not a Claude-maintained queue). Usually empty. The user adds ideas when they want to bias the next experiment. Main agent processes FIFO (top-to-bottom), removing an idea section when it's picked.
+
+```markdown
+# User-suggested ideas (FIFO)
+
+## Try grad-norm clipping
+- theme: optimizer
+- rationale: hunch, not yet swept
+```
+
+### `autoresearch/insights.md`
+
+Reviewer-maintained synthesis. Bounded (~50 lines target; Reviewer prunes). Structured into named sections so insights can be referenced by anchor in idea citations.
+
+```markdown
+# Insights
+
+## Patterns observed
+- LR warmup is necessary for attention-variant experiments; without it, 3/3 diverged (exp 014, 019, 021).
+- Data augmentation at strength > 0.4 consistently hurt val loss on this dataset (exp 008, 011, 028).
+
+## Anti-patterns
+- Dropout on FFN layers: neutral to slightly negative (exp 004, 017).
+
+## Open questions
+- LR-schedule × grad-clipping interaction — exp 009 suggested yes, exp 022 inconclusive.
+
+## Closed directions
+- Mixture-of-experts: out-of-scope per constraints.
+- Recomputation-only tricks: deprioritized per constraints.
+```
+
+### Reading cost at main-agent loop start
+
+At worst, all five files combined:
+
+| File | Typical size |
+|---|---|
+| `config.json` | ~2 KB |
+| `ideas.md` | 0–1.5 KB |
+| `insights.md` | ~2 KB (bounded) |
+| `results.csv` | ~150 B × N (tiny even at N=500) |
+| Experiment frontmatters (scan) | ~500 B × N pending/crashed only |
+
+Main agent context remains well under 10 KB of state per iteration, flat across campaign lifetime.
+
+## Phase 0: Setup
+
+Runs once per campaign, interactive with the user.
+
+### Invocation
+
+```
+/ml-research:autoresearch <campaign-name>   # activate/create named campaign
+/ml-research:autoresearch                   # resume if cwd is inside a worktree, else prompt for name
+```
+
+### Decision flow
+
+```
+if worktree ../autoresearch-<name>/ doesn't exist:
+    git worktree add ../autoresearch-<name> -b autoresearch/<name>    # trunk off current HEAD
+cd ../autoresearch-<name>
+if autoresearch/config.json exists:
+    → Phase 1 (resume)
+else:
+    run setup dialog
+    → Phase 1
+```
+
+### Setup dialog
+
+The main agent does a lightweight codebase scan first (a few `ls`, read `pyproject.toml`/`package.json`/`README.md`, grep for common entrypoint scripts), then walks the user through sections. Each section leads with auto-detected defaults; user confirms or edits. No subagents; all interaction is between main agent and user.
+
+**Question sequence:**
+
+1. **Relevant files.** Heuristics: `src/**/model*.py`, `src/**/net*.py`, files importing torch.nn/flax.linen → proposed `editable`. `config/*.yaml`, `**/data*.py`, `scripts/**` → proposed `read_only`. Present proposal, take edits.
+
+2. **Entrypoints.**
+    - `count_params`: Detect `scripts/count_params.py` or `tools/count_params.py`. If not found, offer to scaffold one from `templates/examples/count_params_lightning.py`.
+    - `launch_experiment`: Detect `scripts/launch.sh`, `scripts/*.sbatch`, Makefile targets. Infer `environment` from script contents (sbatch header → `slurm`, `kubectl` → `k8s`, bare `python` → `local`, …). Present and take edits.
+
+3. **Constraints.** Present skill-default constraints (see below), ask for additions/removals.
+
+4. **Theme priorities.** Present skill-default theme list, ask user to rank into high/medium/low buckets.
+
+5. **Prior findings.** Open-ended: "What have you tried manually on this project? What worked, what didn't? Anything to bias ideation for or against?" Free-form bullet strings.
+
+6. **`debug_cap`.** Default 3; ask if user wants to override.
+
+Before writing, main agent presents a draft `config.json` and asks for confirmation.
+
+### Skill-default constraints (seeded into `constraints` list)
+
+```
+- no change to random seed, step count, validation dataset, validation logic, or validation metrics
+- parameter count must be <= baseline * 1.05
+- no change to core dependencies / package versions
+```
+
+### Skill-default theme list
+
+```
+optimizer, initialization, data_augmentation, architecture,
+regularization, training_objective, tokenization, schedule
+```
+
+`training_objective` = training-loss composition (loss function, auxiliary losses, loss weighting). Explicitly *not* the validation metric — that's frozen by constraint.
+
+### Artifact initialization
+
+After config confirmation, main agent creates:
+
+```
+autoresearch/config.json              # written
+autoresearch/ideas.md                 # empty with comment header
+autoresearch/insights.md              # skeleton with empty Patterns/Anti-patterns/Open-questions/Closed-directions sections
+autoresearch/results.csv              # header row only
+autoresearch/experiments/.gitkeep     # dir preserved in git
+```
+
+### Initial commit
+
+```
+git add autoresearch/
+git commit -m "Initialize autoresearch campaign: <project_name>"
+```
+
+### Phase 0 → Phase 1 handoff
+
+Main agent announces setup complete and begins Phase 1 with a **baseline dispatch** (no Ideator call): experiment 001 = unmodified code. Experimenter runs the `launch_experiment` entrypoint as-is, records metrics, writes `experiments/001-baseline.md` with `result_status: accepted` (trivially). First CSV row written. Normal loop begins thereafter.
+
+### Edit-later semantics
+
+`config.json` is user-editable at any time post-setup. Main agent:
+- Re-reads at every iteration (it's small).
+- May propose edits ("15 experiments in, all attention-variants failed — add to constraints?") but never writes `config.json` without user approval.
+- User is the only writer of `config.json` after Phase 0.
+
+## Phase 1: Loop body
+
+Runs forever after Phase 0. Main agent's per-iteration script:
+
+```
+loop forever:
+    # 1. Small reads
+    read config.json, ideas.md, insights.md, results.csv tail
+    scan experiments/ frontmatters (status fields only)
+
+    # 2. Resumption / reconciliation — idempotent, runs every iteration
+    for each experiment with job_status: pending:
+        probe job state via env-appropriate skill (ml-research:slurm, etc.)
+        if still running:
+            dispatch Experimenter in resume-monitoring mode
+        elif terminated cleanly:
+            dispatch Experimenter in analyze-only mode
+        elif terminated abnormally:
+            update job_status: crashed, record reason, continue
+
+    # 3. Post-experiment housekeeping
+    if any experiment just transitioned to a terminal state:
+        write experiment file + CSV row on trunk, commit
+        if job_status: succeeded && result_status: accepted:
+            squash-merge experiment branch onto trunk
+        # rejected / inconclusive / crashed: branch preserved, no merge
+
+    # 4. Periodic maintenance
+    if succeeded-count since last Reviewer >= 5:
+        dispatch Reviewer
+            apply insights delta to insights.md on trunk, commit
+
+    # 5. Idea selection
+    if ideas.md has items:
+        next_idea = pop top item from ideas.md, commit on trunk
+    else:
+        dispatch Ideator
+            next_idea = returned idea (with citations)
+
+    # 6. Experimenter dispatch
+    assign next experiment ID (auto-increment from experiments/ dir)
+    create branch autoresearch/<campaign>/NNN-<slug> off trunk
+    dispatch Experimenter with next_idea + branch name
+        Experimenter runs its internal debug loop up to debug_cap
+        returns structured summary + narrative text
+    apply results on trunk:
+        write experiments/NNN-<slug>.md
+        append CSV row if succeeded
+        commit on trunk
+        if accepted → squash-merge branch
+```
+
+### Git choreography
+
+| Actor | Branch | Writes |
+|---|---|---|
+| Main agent | trunk (`autoresearch/<campaign>`) | `config.json` (rarely), `ideas.md`, `insights.md`, `results.csv`, `experiments/*.md`, branch merges |
+| Experimenter | experiment branch (`autoresearch/<campaign>/NNN-<slug>`) | code files only (matching `relevant_files.editable`). Does NOT touch `autoresearch/*` tracking files. |
+| Ideator | none | no disk writes |
+| Reviewer | none | no disk writes — returns delta; main agent applies |
+
+**Experiment branch lifecycle:**
+
+1. Main agent: `git checkout -b autoresearch/<campaign>/NNN-<slug>` off trunk HEAD.
+2. Dispatch Experimenter on that branch.
+3. Experimenter commits code changes on the branch.
+4. Main agent `git checkout <trunk>`, writes experiment file + CSV row, commits on trunk.
+5. If accepted: `git merge --squash autoresearch/<campaign>/NNN-<slug>` brings the code change onto trunk. Branch is preserved (not deleted — audit trail).
+6. If rejected / inconclusive / crashed: branch preserved as-is, no merge. Trunk has the experiment file and CSV row; trunk does NOT have the code change.
+
+Every experiment's code is preserved on its branch forever, regardless of outcome. Auditability requirement met in full.
+
+**No rebasing onto `main`.** The campaign trunk is self-contained. Reconciling with `main` at the end (if ever) is a human decision outside the skill's scope.
+
+### Monitor usage
+
+The Experimenter uses `Monitor` inside its dispatch to stream job-state transitions (one notification per terminal state, not per-poll). The main agent does not use `Monitor` directly — it waits synchronously on the Experimenter dispatch.
+
+### Retry policy
+
+Once the Experimenter exits with `job_status: crashed` (debug-cap exhausted), the status is sticky. Main agent does **not** auto-retry. The user can manually prompt "retry experiment 042" to force a new Experimenter dispatch on that branch; otherwise it stays crashed, and the Ideator treats it as "tried, didn't work" when avoiding duplicates.
+
+### Autonomy principle
+
+Main agent prompts the user only during Phase 0 setup, when responding to user-initiated prompts (charter edit requests, explicit "retry experiment X"), or when a genuinely unresolvable blocker surfaces (e.g., config.json references a missing entrypoint). Every crashed job, failed experiment, and exhausted queue is handled by the agent itself (mark, retry-if-allowed, dispatch Reviewer, loop forward). A persistent blocker gets logged to `insights.md` and the agent moves on to a different experiment rather than hanging.
+
+## Subagents
+
+### Definitions
+
+Three agent types in the plugin:
+
+```
+plugins/ml-research/agents/
+├── autoresearch-ideator.md
+├── autoresearch-experimenter.md
+└── autoresearch-reviewer.md
+```
+
+Each has frontmatter (`name`, `description`, `tools` allowlist) plus a detailed system prompt. Main agent dispatches via the `Agent` tool with `subagent_type: "ml-research:autoresearch-<role>"`.
+
+### Tool allowlists
+
+| Subagent | Tools |
+|---|---|
+| Ideator | `WebSearch, WebFetch, Read, Grep, Bash (read-only)` |
+| Experimenter | `Bash, Read, Edit, Write, Grep, Monitor, Skill (ml-research:slurm, ml-research:model-training, and any env-specific helper)` |
+| Reviewer | `Read, Grep, Bash (read-only)` |
+
+Read-only-ness for Ideator and Reviewer is enforced by omitting Edit/Write. They return structured output; the main agent applies changes to disk.
+
+### Input contract (common dispatch header)
+
+Every dispatch prompt includes:
+
+```
+Campaign: <project_name>
+Trunk: autoresearch/<project_name> @ <git SHA>
+config.json: <embedded JSON, full>
+insights.md: <embedded, full — bounded ~50 lines>
+Recent experiments (CSV tail, last ~20 rows): <embedded>
+```
+
+Plus a role-specific section (details in "Output contracts" below).
+
+### Output contracts
+
+**Ideator returns** a single JSON object:
+
+```json
+{
+  "title": "GELU in FFN",
+  "theme": "architecture",
+  "rationale": "1-3 sentences",
+  "expected": "1-2 sentences",
+  "sources": [
+    {"url": "https://arxiv.org/abs/2301.12345", "note": "..."},
+    {"ref": "insights.md#activations-underexplored", "note": "..."}
+  ],
+  "parent": 37
+}
+```
+
+**Sources requirements (system-prompt-enforced; main agent rejects malformed returns):**
+
+1. **At least one source required.** Non-negotiable — empty `sources: []` triggers rejection.
+2. **Strongly encouraged: an official reference implementation.** Author's codebase, library's canonical, paper's companion repo.
+3. **Otherwise encouraged: a reputable reference implementation** (HuggingFace, nanoGPT, fairseq, etc.).
+4. **Fallback: paper or authoritative blog post.** Acceptable when no reference implementation exists publicly. Ideator must flag this in `rationale`: "no reference implementation available; Experimenter will implement from paper description."
+
+Internal references (`ref:` to prior experiments or `insights.md` anchors) are valid sources and count toward the "at least one" requirement alone — typical for ideas that are variations on already-explored ground.
+
+Source quality is a ranking dimension: between two ideas of comparable expected impact, the Ideator returns the one with stronger reference-implementation grounding.
+
+**Experimenter returns** (success path):
+
+```json
+{
+  "experiment_id": 42,
+  "branch": "autoresearch/my-project/042-gelu-ffn",
+  "commit": "abc123",
+  "job_status": "succeeded",
+  "result_status": "accepted",
+  "attempts": 1,
+  "job_ids": ["12345"],
+  "metrics": {
+    "trainable_params": 1234567,
+    "total_params": 1234567,
+    "final_train_loss": 2.31,
+    "final_val_loss": 2.41
+  },
+  "acceptance_recommendation": "accept",
+  "reasoning_short": "3% val loss improvement over baseline, stable training, no added complexity",
+  "follow_ups": [
+    "Try combining with warmup schedule (insight #2 suggests interaction)"
+  ],
+  "narrative_markdown": "## Change\n...\n## Training dynamics\n...\n## Analysis\n..."
+}
+```
+
+`narrative_markdown` is the full body written to `experiments/NNN-<slug>.md` by the main agent. `follow_ups` is free-text candidate ideas — the main agent may append to `ideas.md` or ignore.
+
+**Experimenter returns** (crash path, debug-cap exhausted):
+
+```json
+{
+  "experiment_id": 42,
+  "branch": "autoresearch/my-project/042-gelu-ffn",
+  "commit": "abc123",
+  "job_status": "crashed",
+  "result_status": null,
+  "attempts": 3,
+  "job_ids": ["12345", "12346", "12347"],
+  "crash_reasons": ["OOM", "NaN loss", "NaN loss"],
+  "narrative_markdown": "## Change\n...\n## Attempts log\n- attempt 1 (job 12345): OOM...\n- attempt 2: ..."
+}
+```
+
+**Reviewer returns** an insights delta:
+
+```json
+{
+  "insights_added": [
+    {"section": "Patterns observed", "text": "..."}
+  ],
+  "insights_updated": [
+    {"section": "Anti-patterns", "old_text": "...", "new_text": "..."}
+  ],
+  "insights_removed": [
+    {"section": "Open questions", "text": "..."}
+  ],
+  "strategic_note": "Attention-variant directions have yielded 0/4 accepted; suggest deprioritizing."
+}
+```
+
+Main agent applies the delta to `insights.md` on trunk and commits. `strategic_note` is informational — surfaced to the user on next prompt, not auto-applied.
+
+### Experimenter's internal debug loop
+
+```
+attempt = 1
+while attempt <= debug_cap:
+    if attempt == 1:
+        implement the change on the branch, commit
+    else:
+        apply diagnosed fix, commit
+    run count_params entrypoint, verify param budget (<= baseline * 1.05)
+    run launch_experiment entrypoint, get job_id
+    monitor job to terminal state via env-appropriate skill
+    if job succeeded:
+        analyze logs/metrics
+        return success summary + narrative
+    else:  # job crashed
+        diagnose from logs (OOM, NaN, python error, node fail, timeout, unknown)
+        append to "Attempts log" in narrative
+        if fixable and attempt < debug_cap:
+            attempt += 1
+            continue
+        else:
+            return crash summary
+```
+
+**Diagnosis → fix table:**
+
+| Diagnosis | Fix | Fixable? |
+|---|---|---|
+| OOM | Reduce batch size, increase grad accumulation | yes |
+| NaN / inf loss | Add gradient clipping, lower LR, add warmup | yes |
+| Python exception / traceback | Read traceback, patch the code change | yes |
+| Timeout (exceeded wall clock) | Usually not fixable within debug budget | no |
+| Node failure / preemption | Resubmit unchanged (infra issue) | yes (cheap) |
+| Unknown / unparseable logs | Give up | no |
+
+### Subagent hard rules (encoded in each system prompt)
+
+- **Ideator and Reviewer:** no disk writes, no code modifications, no commits. Return structured output only.
+- **Experimenter:**
+    - Writes only to files matching `relevant_files.editable`.
+    - Does not touch `autoresearch/*` tracking files (main agent owns those).
+    - Commits only on the experiment branch. Never commits on trunk.
+    - No `git merge`, `git rebase`, or destructive git ops.
+- **Every subagent:**
+    - Must respect all `constraints` from `config.json`.
+    - Must not propose or implement changes that modify validation dataset, validation logic, or validation metrics.
+
+## Files & migration
+
+### Plugin-shipped files (new layout)
+
+```
+plugins/ml-research/
+├── agents/                                    # NEW — subagent definitions
+│   ├── autoresearch-ideator.md
+│   ├── autoresearch-experimenter.md
+│   └── autoresearch-reviewer.md
+└── skills/autoresearch/
+    ├── SKILL.md                               # orchestration prompt (~200-300 lines)
+    └── templates/
+        ├── config.json                        # schema stub for Phase 0 scaffold
+        ├── ideas.md                           # skeleton with comment header
+        ├── insights.md                        # skeleton with empty sections
+        ├── results.csv                        # header row only
+        └── examples/                          # NEW — copy-and-adapt reference implementations
+            ├── count_params_lightning.py      # current count_params.py, relabeled as example
+            └── launch_slurm_lightning.sbatch  # current launch.sbatch, relabeled
+```
+
+### User-provided (in their project repo)
+
+- Project source tree (untouched by the skill's own files).
+- Executable for `entrypoints.count_params.command` (contract: prints JSON `{"trainable_params": int, "total_params": int}` to stdout).
+- Executable for `entrypoints.launch_experiment.command` (contract: submits a job, prints job ID to stdout, accepts training overrides as positional args).
+- `config.json` (generated at Phase 0 setup).
+
+### SKILL.md shape (main agent's prompt)
+
+Thin — orchestration only, no ML-research expertise. Length target: 200–300 lines. Structure:
+
+- Frontmatter: name, description, invocation args.
+- Identity: orchestrator; never does research itself.
+- Phase 0 procedure (invocation, worktree creation, setup dialog, defaults, artifact init, initial commit).
+- Phase 1 loop body (resumption, idea selection, dispatch patterns, post-dispatch housekeeping).
+- Git choreography rules.
+- Resumption protocol.
+- Subagent dispatch patterns (common header, role-specific sections, return-contract validation).
+- Autonomy principle.
+
+### Agent definition files (long; carry the deep domain expertise)
+
+Lengths are approximate upper targets — these don't touch main-agent context, so there's no penalty for depth:
+
+- **`autoresearch-ideator.md`** (~400 lines): research ideation — reading past experiments, evaluating expected impact, hunting for reference implementations, duplicate-checking, writing good rationales, citation-quality rules.
+- **`autoresearch-experimenter.md`** (~600 lines): implementation — localizing code changes, running entrypoints, `Monitor` patterns, crash diagnosis repertoire, fix-per-crash-type playbook, narrative-writing conventions.
+- **`autoresearch-reviewer.md`** (~250 lines): synthesis — efficient scan of N experiment files, pattern identification (not restatement), pruning stale insights, grounding every insight in experiment IDs, strategic-note guidelines.
+
+### Migration from current skill
+
+Compared to the current `plugins/ml-research/skills/autoresearch/`:
+
+- **Keep:** skill path. `config.yaml` (Lightning trainer overrides) could stay as an example template but is no longer mandatory.
+- **Move:** `scripts/count_params.py` → `templates/examples/count_params_lightning.py`. `scripts/launch.sbatch` → `templates/examples/launch_slurm_lightning.sbatch`.
+- **Drop:** current `templates/autoresearch_{ideas,log,results.csv}` — replaced by new template shapes. Current SKILL.md — rewritten from scratch against this design.
+- **New:** three agent definition files in `plugins/ml-research/agents/`.
+
+## Out of scope for this spec
+
+The following are explicitly deferred; they may warrant their own specs later:
+
+- **Pipelining** Ideator for experiment N+1 while Experimenter runs N. Simpler serial loop first.
+- **Multi-experiment parallelism** (dispatching multiple Experimenters concurrently). Single-stream first; parallelism later if it doesn't compromise context hygiene.
+- **Automated rebase onto `main`.** Left as a human decision.
+- **Auto-promotion of campaign trunk to `main` on success.** Also a human decision.
+- **Cross-campaign learning** (a Reviewer that synthesizes insights across multiple campaigns). Per-campaign isolation is sufficient for now.
+- **API-level features beyond what Claude Code exposes.** The `advisor_20260301` tool and `clear_tool_uses_20250919` context-editing strategy are out of reach from inside a Claude Code skill; their Claude Code-native analogues (subagents and harness-managed compaction) are sufficient for this design.

--- a/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
@@ -225,6 +225,8 @@ Runs once per campaign, interactive with the user.
 /ml-research:autoresearch                   # resume if cwd is inside a worktree, else prompt for name
 ```
 
+The `<campaign-name>` argument is the same string as the `project_name` field in `config.json`. The two are used interchangeably in this spec — invocation arg, worktree directory suffix, trunk branch suffix, and config field all share the value.
+
 ### Decision flow
 
 ```
@@ -320,43 +322,68 @@ loop forever:
     # 2. Resumption / reconciliation — idempotent, runs every iteration
     for each experiment with job_status: pending:
         probe job state via env-appropriate skill (ml-research:slurm, etc.)
-        if still running:
-            dispatch Experimenter in resume-monitoring mode
+        if no job_id recorded yet (mid-dispatch crash before launch):
+            # Stub exists, branch may or may not, Experimenter never started
+            # Re-dispatch fresh (Experimenter idempotently re-uses existing branch)
+            result = dispatch Experimenter in fresh mode
+            post_experimenter(result)
+        elif still running:
+            result = dispatch Experimenter in resume-monitoring mode
+            post_experimenter(result)
         elif terminated cleanly:
-            dispatch Experimenter in analyze-only mode
+            result = dispatch Experimenter in analyze-only mode
+            post_experimenter(result)
         elif terminated abnormally:
-            update job_status: crashed, record reason, continue
+            update experiment file: job_status: crashed + crash_reason in narrative
+            commit on trunk
+            continue
+    # Also: detect orphan experiment-named branches with no experiment file (shouldn't
+    # happen given the stub-first ordering below, but if it does, log to insights.md
+    # and leave alone — user can investigate)
 
-    # 3. Post-experiment housekeeping
-    if any experiment just transitioned to a terminal state:
-        write experiment file + CSV row on trunk, commit
-        if job_status: succeeded && result_status: accepted:
-            squash-merge experiment branch onto trunk
-        # rejected / inconclusive / crashed: branch preserved, no merge
-
-    # 4. Periodic maintenance
+    # 3. Periodic maintenance
     if succeeded-count since last Reviewer >= 5:
-        dispatch Reviewer
-            apply insights delta to insights.md on trunk, commit
+        delta = dispatch Reviewer
+        apply insights delta to insights.md on trunk, commit
 
-    # 5. Idea selection
+    # 4. Idea selection
     if ideas.md has items:
         next_idea = pop top item from ideas.md, commit on trunk
     else:
-        dispatch Ideator
-            next_idea = returned idea (with citations)
+        next_idea = dispatch Ideator   # returns one idea with citations
 
-    # 6. Experimenter dispatch
-    assign next experiment ID (auto-increment from experiments/ dir)
-    create branch autoresearch/<campaign>/NNN-<slug> off trunk
-    dispatch Experimenter with next_idea + branch name
-        Experimenter runs its internal debug loop up to debug_cap
-        returns structured summary + narrative text
-    apply results on trunk:
-        write experiments/NNN-<slug>.md
-        append CSV row if succeeded
+    # 5. New experiment dispatch
+    NNN = next experiment ID (auto-increment from experiments/ dir)
+    slug = derive_slug(next_idea.title)
+    # Stub-first ordering: create the experiment-file marker BEFORE the branch and
+    # BEFORE the dispatch. If anything below crashes mid-flight, resumption (step 2)
+    # finds the stub and reconciles.
+    write experiments/NNN-<slug>.md as a stub (frontmatter only):
+        id: NNN, title, date, theme, sources from next_idea,
+        job_status: pending, result_status: null, attempts: 1
+    commit stub on trunk
+    git branch autoresearch/<campaign>/NNN-<slug>     # branch ref created off trunk; main agent stays on trunk
+    result = dispatch Experimenter with next_idea + branch name + experiment_id=NNN
+        # Experimenter operates on the branch (recommended: isolation: "worktree" so it
+        # gets its own worktree on the branch and main agent's trunk worktree is untouched)
+        # Experimenter runs its internal debug loop up to debug_cap
+        # returns structured summary + narrative text
+    post_experimenter(result)
+
+
+# Single post-Experimenter handler, invoked after every dispatch (resumption or new):
+def post_experimenter(result):
+    # Main agent is on trunk throughout this handler.
+    # The stub experiment file already exists (written before dispatch); this overwrites it.
+    overwrite experiments/<result.experiment_id>-<slug>.md
+        (frontmatter from result + result.narrative_markdown as body)
+    if result.job_status == "succeeded":
+        append CSV row from result.metrics, result.experiment_id, result.branch, result.commit
+    commit on trunk
+    if result.job_status == "succeeded" and result.result_status == "accepted":
+        git merge --squash <result.branch>
         commit on trunk
-        if accepted → squash-merge branch
+    # rejected / inconclusive / crashed: branch preserved as-is, no merge
 ```
 
 ### Git choreography
@@ -370,12 +397,15 @@ loop forever:
 
 **Experiment branch lifecycle:**
 
-1. Main agent: `git checkout -b autoresearch/<campaign>/NNN-<slug>` off trunk HEAD.
-2. Dispatch Experimenter on that branch.
-3. Experimenter commits code changes on the branch.
-4. Main agent `git checkout <trunk>`, writes experiment file + CSV row, commits on trunk.
-5. If accepted: `git merge --squash autoresearch/<campaign>/NNN-<slug>` brings the code change onto trunk. Branch is preserved (not deleted — audit trail).
-6. If rejected / inconclusive / crashed: branch preserved as-is, no merge. Trunk has the experiment file and CSV row; trunk does NOT have the code change.
+1. Main agent (on trunk): `git branch autoresearch/<campaign>/NNN-<slug>` — creates the branch ref off trunk HEAD without checking it out. Main agent's working tree stays on trunk.
+2. Main agent dispatches Experimenter with `isolation: "worktree"` (recommended) or equivalent, passing the branch name. Experimenter gets its own worktree on the branch; main agent's trunk worktree is untouched.
+3. Experimenter commits code changes in its isolated worktree. Commits land on the branch in the shared `.git` repo, visible from any worktree.
+4. Experimenter returns its result. The isolated worktree is auto-cleaned (per Agent-tool semantics).
+5. Main agent (still on trunk) writes experiment file + CSV row, commits on trunk.
+6. If accepted: `git merge --squash autoresearch/<campaign>/NNN-<slug>` from trunk brings the code change onto trunk. Branch is preserved (not deleted — audit trail).
+7. If rejected / inconclusive / crashed: branch preserved as-is, no merge. Trunk has the experiment file and CSV row; trunk does NOT have the code change.
+
+If `isolation: "worktree"` is not used (e.g., the harness doesn't support it for some reason), the fallback is for the main agent to `git checkout <branch>` before dispatching and `git checkout <trunk>` after the dispatch returns. This works but is fragile across crashes (a mid-dispatch interruption leaves the main agent's working tree on the experiment branch). Worktree isolation is strongly preferred.
 
 Every experiment's code is preserved on its branch forever, regardless of outcome. Auditability requirement met in full.
 

--- a/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
@@ -78,11 +78,18 @@ User-authoritative, written once at Phase 0 setup, read by the main agent at eve
     "launch_experiment": {
       "command": "scripts/launch.sh",
       "environment": "slurm"
-    }
+    },
+    "read_metrics":      { "command": "scripts/read_metrics.sh" }
   },
+  "experiment_budget": {
+    "max_steps": 1000,
+    "max_wall_time": "00:30:00"
+  },
+  "compile_cache_dir": "~/.cache/torch_compile/<project_name>",
   "debug_cap": 3,
   "constraints": [
-    "no change to random seed, step count, validation dataset, validation logic, or validation metrics",
+    "no change to random seed, validation dataset, validation logic, or validation metrics",
+    "no change to the experiment budget defined in config.json (experiment_budget)",
     "parameter count must be <= baseline * 1.05",
     "no change to core dependencies / package versions"
   ],
@@ -101,9 +108,14 @@ User-authoritative, written once at Phase 0 setup, read by the main agent at eve
 
 Notes on semantics:
 
-- **`relevant_files`** is a hard safety rail for Experimenter. Shell-style globs (`**`, `*`, `?`). Subagents may only *edit* files matching `editable`; they may *read* files matching `read_only`; files outside both lists are implicitly off-limits.
-- **`entrypoints`** — pluggable user-provided commands. Contract for each is documented in SKILL.md (not duplicated per-campaign). `count_params.command` must print JSON with keys `trainable_params`, `total_params` to stdout. `launch_experiment.command` must submit a job, print its job ID to stdout, and accept training overrides as positional args.
+- **`relevant_files`** is a hard safety rail for Experimenter. Shell-style globs (`**`, `*`, `?`). Subagents may *edit existing files or create new files* at paths matching `editable`; they may *read* files matching `read_only`; files outside both lists are implicitly off-limits to both reads and writes (other than the standard project-orientation reads like `pyproject.toml` or `README.md`). The constraint is about which paths can be touched, not whether the files preexist.
+- **`entrypoints`** — pluggable user-provided commands. All contracts are documented in SKILL.md (not duplicated per-campaign):
+    - `count_params.command` must print JSON with keys `trainable_params`, `total_params` to stdout.
+    - `launch_experiment.command` must submit a job, print its job ID to stdout, and accept training overrides as positional args. **It must also write final-metrics output that `read_metrics.command` can return.** No agent ever streams stdout/stderr from `launch_experiment.command` into its context — the only path from job to context is via `read_metrics`.
+    - `read_metrics.command` is invoked after the job completes (with `JOB_ID` as an env var) and must print JSON to stdout containing at minimum `{"final_train_loss": float, "final_val_loss": float}`. Other metrics keys (e.g. best-val-loss, GPU utilization) are allowed and surfaced into the experiment file. Implementations: read a metrics file the launcher wrote, query a tracking service (W&B, MLflow), or grep a structured log line.
 - **`environment`** is a free-form hint string (`"slurm"`, `"local"`, `"k8s"`, `"ray"`, …) that tells the Experimenter which env-specific skill (if any) to invoke for monitoring.
+- **`experiment_budget`** caps each experiment's compute. At least one of `max_steps` or `max_wall_time` (HH:MM:SS) must be set. The `launch_experiment` entrypoint is responsible for honoring these; the Experimenter passes them as overrides if the launcher accepts them, and otherwise relies on the launcher's own defaults. Frozen by constraint after Phase 0 — changing the budget mid-campaign would break experiment comparability.
+- **`compile_cache_dir`** (optional). If set, the Experimenter exports `TORCHINDUCTOR_CACHE_DIR` (or the equivalent env var for the user's compile backend) when launching a job. The cache is shared across experiments for speed; the Experimenter wipes it before launching when `theme: architecture` (architecture changes invalidate compiled kernels). Omit this field if the project doesn't use `torch.compile`.
 - **`debug_cap`** caps the Experimenter's internal retry loop. Default 3. Counts total attempts including the first launch.
 - **`constraints`** is a flat list of free-text rules. Phase 0 seeds skill-default constraints; user can add/remove.
 - **`theme_priorities`** ranks themes. Skill-default theme list: `optimizer, initialization, data_augmentation, architecture, regularization, training_objective, tokenization, schedule`. The `training_objective` theme refers to the *training* loss / objective function; the validation metric is frozen by constraint and can never be a theme target.
@@ -180,7 +192,7 @@ One row per `job_status: succeeded` experiment. Crashed experiments get no CSV r
 
 ### `autoresearch/insights.md`
 
-Reviewer-maintained synthesis. Bounded (~50 lines target; Reviewer prunes). Structured into named sections so insights can be referenced by anchor in idea citations.
+Reviewer-maintained synthesis. No hard size bound — the Reviewer is responsible for keeping it useful (consolidating, pruning stale entries, removing redundancy). Structured into named sections so insights can be referenced by anchor in idea citations.
 
 ```markdown
 # Insights
@@ -208,7 +220,7 @@ At worst, all five files combined:
 |---|---|
 | `config.json` | ~2 KB |
 | `ideas.md` | 0–1.5 KB |
-| `insights.md` | ~2 KB (bounded) |
+| `insights.md` | small to start; Reviewer prunes — should stay manageable in practice |
 | `results.csv` | ~150 B × N (tiny even at N=500) |
 | Experiment frontmatters (scan) | ~500 B × N pending/crashed only |
 
@@ -251,24 +263,32 @@ The main agent does a lightweight codebase scan first (a few `ls`, read `pyproje
 2. **Entrypoints.**
     - `count_params`: Detect `scripts/count_params.py` or `tools/count_params.py`. If not found, offer to scaffold one from `templates/examples/count_params_lightning.py`.
     - `launch_experiment`: Detect `scripts/launch.sh`, `scripts/*.sbatch`, Makefile targets. Infer `environment` from script contents (sbatch header → `slurm`, `kubectl` → `k8s`, bare `python` → `local`, …). Present and take edits.
+    - `read_metrics`: Ask the user how the launcher persists final metrics, and propose a one-line command that returns them as JSON. Common patterns: `cat $JOB_DIR/metrics.json`, a wandb-API query, or a `grep`+`jq` over a structured log line. If unclear, offer to scaffold a small reader script.
 
-3. **Constraints.** Present skill-default constraints (see below), ask for additions/removals.
+3. **Experiment budget.** Ask for `max_steps` and/or `max_wall_time` (at least one required). Defaults: none — must be user-set, since "what is a small experiment" is project-specific.
 
-4. **Theme priorities.** Present skill-default theme list, ask user to rank into high/medium/low buckets.
+4. **`torch.compile` cache.** Ask whether the project uses `torch.compile` (or equivalent). If yes, propose a default `compile_cache_dir` under `~/.cache/torch_compile/<project_name>`. If no, omit the field.
 
-5. **Prior findings.** Open-ended: "What have you tried manually on this project? What worked, what didn't? Anything to bias ideation for or against?" Free-form bullet strings.
+5. **Constraints.** Present skill-default constraints (see below), ask for additions/removals.
 
-6. **`debug_cap`.** Default 3; ask if user wants to override.
+6. **Theme priorities.** Present skill-default theme list, ask user to rank into high/medium/low buckets.
+
+7. **Prior findings.** Open-ended: "What have you tried manually on this project? What worked, what didn't? Anything to bias ideation for or against?" Free-form bullet strings.
+
+8. **`debug_cap`.** Default 3; ask if user wants to override.
 
 Before writing, main agent presents a draft `config.json` and asks for confirmation.
 
 ### Skill-default constraints (seeded into `constraints` list)
 
 ```
-- no change to random seed, step count, validation dataset, validation logic, or validation metrics
+- no change to random seed, validation dataset, validation logic, or validation metrics
+- no change to the experiment budget defined in config.json (experiment_budget)
 - parameter count must be <= baseline * 1.05
 - no change to core dependencies / package versions
 ```
+
+(The "no change to experiment budget" constraint is a hard rule; the budget is set once at Phase 0 and cannot be edited later — see "Config.json freeze" below.)
 
 ### Skill-default theme list
 
@@ -302,12 +322,15 @@ git commit -m "Initialize autoresearch campaign: <project_name>"
 
 Main agent announces setup complete and begins Phase 1 with a **baseline dispatch** (no Ideator call): experiment 001 = unmodified code. Experimenter runs the `launch_experiment` entrypoint as-is, records metrics, writes `experiments/001-baseline.md` with `result_status: accepted` (trivially). First CSV row written. Normal loop begins thereafter.
 
-### Edit-later semantics
+### Config.json freeze
 
-`config.json` is user-editable at any time post-setup. Main agent:
-- Re-reads at every iteration (it's small).
-- May propose edits ("15 experiments in, all attention-variants failed — add to constraints?") but never writes `config.json` without user approval.
-- User is the only writer of `config.json` after Phase 0.
+**`config.json` is frozen after Phase 0.** Once initialized and committed, it is not edited — not by the main agent, not by subagents, not by the user mid-campaign.
+
+The reason: changing constraints, themes, entrypoints, or `experiment_budget` mid-campaign would compromise experiment comparability. Two experiments run under different `experiment_budget` values aren't comparable on val loss; two experiments evaluated under different `constraints` may conflict on what counts as acceptable. The campaign is a controlled study; `config.json` is the protocol.
+
+If the user genuinely needs to change settings, the path is: complete or abandon the current campaign, start a new campaign with a different `project_name`. Multiple campaigns can coexist in the same project (per the multi-campaign isolation property).
+
+The main agent re-reads `config.json` at every iteration to recover its working knowledge after compaction, but it does not modify the file. If a subagent ever attempts to write to `config.json`, the main agent rejects the resulting return as malformed.
 
 ## Phase 1: Loop body
 
@@ -315,8 +338,8 @@ Runs forever after Phase 0. Main agent's per-iteration script:
 
 ```
 loop forever:
-    # 1. Small reads
-    read config.json, ideas.md, insights.md, results.csv tail
+    # 1. Small reads — full files; all bounded for the campaign's lifetime
+    read config.json, ideas.md, insights.md, results.csv (full)
     scan experiments/ frontmatters (status fields only)
 
     # 2. Resumption / reconciliation — idempotent, runs every iteration
@@ -409,11 +432,30 @@ If `isolation: "worktree"` is not used (e.g., the harness doesn't support it for
 
 Every experiment's code is preserved on its branch forever, regardless of outcome. Auditability requirement met in full.
 
-**No rebasing onto `main`.** The campaign trunk is self-contained. Reconciling with `main` at the end (if ever) is a human decision outside the skill's scope.
+### Acceptance criteria
+
+The Experimenter recommends `result_status` based on the experiment's val loss compared to the **current best** — not the original baseline (experiment 001). "Current best" = the lowest `final_val_loss` among all experiments with `job_status: succeeded` and `result_status: accepted`. The main agent provides this number in the Experimenter's input contract so the Experimenter doesn't need to recompute it.
+
+Recommendation rules (Experimenter applies; main agent rubber-stamps):
+
+| Val-loss delta vs. current best | Recommendation |
+|---|---|
+| improvement > 1% (i.e., new < best * 0.99) | `accepted` (provided training was stable; see below) |
+| 0–1% improvement | `inconclusive` (log; may revisit later, possibly combined with other changes) |
+| no improvement or regression | `rejected` |
+
+Stability gate (applied even when val-loss improves): training must show no divergence, no oscillation past the early phase, and no NaN/inf. If the gate fails, the recommendation drops to `rejected` regardless of val-loss improvement.
+
+Complexity check: `acceptance_recommendation` should also weigh added complexity against the magnitude of improvement. The Experimenter's `reasoning_short` records this judgment.
 
 ### Monitor usage
 
-The Experimenter uses `Monitor` inside its dispatch to stream job-state transitions (one notification per terminal state, not per-poll). The main agent does not use `Monitor` directly — it waits synchronously on the Experimenter dispatch.
+The Experimenter uses `Monitor` inside its dispatch to stream job-state transitions (one notification per terminal state, not per-poll). The main agent does not use `Monitor` against the Experimenter dispatch itself, for two reasons:
+
+1. **`Monitor` watches a script's stdout; subagent dispatches via the `Agent` tool don't expose stdout in that form.** The `Agent` tool returns one final message (sync) or one completion notification (with `run_in_background: true`) — neither is a stream. So Monitor isn't a fit for Experimenter dispatches even mechanically.
+2. **The main agent has no in-flight work to do during an Experimenter dispatch under the current design** (serial loop). Pipelining the next Ideator call against an in-flight Experimenter is plausible future work but is explicitly out of scope here.
+
+So the dispatch model stays: **main agent dispatches Experimenter synchronously and awaits the structured return.** The Experimenter is internally responsible for streaming progress (via Monitor on the underlying job) and condensing it to its return.
 
 ### Retry policy
 
@@ -436,7 +478,17 @@ plugins/ml-research/agents/
 └── autoresearch-reviewer.md
 ```
 
-Each has frontmatter (`name`, `description`, `tools` allowlist) plus a detailed system prompt. Main agent dispatches via the `Agent` tool with `subagent_type: "ml-research:autoresearch-<role>"`.
+Each has frontmatter (`name`, `description`, `tools` allowlist, default `model` and `effort`) plus a detailed system prompt. Main agent dispatches via the `Agent` tool with `subagent_type: "ml-research:autoresearch-<role>"` and an optional `model` override.
+
+### Default model + effort per subagent
+
+| Subagent | Default model | Default effort | Reasoning |
+|---|---|---|---|
+| Ideator | Opus 4.7 | medium | Idea quality is high-leverage and infrequent (one call per loop iteration when the user queue is empty). The cost of a bad idea is a wasted experiment (substantial GPU time); spending Opus tokens to pick well pays for itself easily. |
+| Experimenter | Sonnet 4.6 | medium | Bulk of token generation is mechanical (file edits, command running, log reading). Sonnet is more than adequate at the implementation level. The debug loop's diagnoses use the same model — Sonnet handles standard crash patterns well. |
+| Reviewer | Opus 4.7 | medium | Cross-experiment synthesis is high-leverage and infrequent (every 5 succeeded experiments). Opus is better at finding patterns vs. just restating individual experiment summaries. |
+
+These are defaults in each agent's frontmatter; the main agent can override per dispatch (e.g., promote Experimenter to Opus for an unusually tricky implementation). User can also override at the plugin level.
 
 ### Tool allowlists
 
@@ -456,8 +508,9 @@ Every dispatch prompt includes:
 Campaign: <project_name>
 Trunk: autoresearch/<project_name> @ <git SHA>
 config.json: <embedded JSON, full>
-insights.md: <embedded, full — bounded ~50 lines>
-Recent experiments (CSV tail, last ~20 rows): <embedded>
+insights.md: <embedded, full>
+Results CSV: <embedded, full — typically tens of rows, each ~150 B>
+Current best: experiment <id>, final_val_loss <number>
 ```
 
 Plus a role-specific section (details in "Output contracts" below).
@@ -491,6 +544,17 @@ Internal references (`ref:` to prior experiments or `insights.md` anchors) are v
 
 Source quality is a ranking dimension: between two ideas of comparable expected impact, the Ideator returns the one with stronger reference-implementation grounding.
 
+**Curated starter source list** — the Ideator's system prompt includes a curated list of sites to consult first when looking for techniques. Recommended starting set (edit per project domain in the agent file):
+
+- arxiv (cs.LG, cs.CL, cs.CV — theme/domain dependent)
+- paperswithcode.com — for paper → reference-impl crosswalk
+- HuggingFace docs and model repos
+- Major reference codebases for the model family (e.g., nanoGPT, fairseq, jax-models, levanter)
+- distill.pub, lilianweng.github.io, sebastianraschka.com — for high-quality digest articles
+- Recent NeurIPS / ICML / ICLR proceedings
+
+The Ideator is expected to consult these *before* speculating from first principles. Web search calls land in the Ideator's context, not the main agent's.
+
 **Experimenter returns** (success path):
 
 ```json
@@ -509,7 +573,7 @@ Source quality is a ranking dimension: between two ideas of comparable expected 
     "final_val_loss": 2.41
   },
   "acceptance_recommendation": "accept",
-  "reasoning_short": "3% val loss improvement over baseline, stable training, no added complexity",
+  "reasoning_short": "3% val loss improvement over current best (exp 037), stable training, no added complexity",
   "follow_ups": [
     "Try combining with warmup schedule (insight #2 suggests interaction)"
   ],
@@ -564,10 +628,15 @@ while attempt <= debug_cap:
     else:
         apply diagnosed fix, commit
     run count_params entrypoint, verify param budget (<= baseline * 1.05)
+    if compile_cache_dir is set and theme == "architecture":
+        wipe compile_cache_dir before launch (architecture changes invalidate compiled kernels)
     run launch_experiment entrypoint, get job_id
+        (export TORCHINDUCTOR_CACHE_DIR=compile_cache_dir if set)
     monitor job to terminal state via env-appropriate skill
+    while job runs: poll nvidia-smi periodically; record GPU utilization
     if job succeeded:
-        analyze logs/metrics
+        run read_metrics entrypoint, get metrics JSON
+        analyze metrics, GPU utilization, training curves
         return success summary + narrative
     else:  # job crashed
         diagnose from logs (OOM, NaN, python error, node fail, timeout, unknown)
@@ -590,17 +659,45 @@ while attempt <= debug_cap:
 | Node failure / preemption | Resubmit unchanged (infra issue) | yes (cheap) |
 | Unknown / unparseable logs | Give up | no |
 
+### GPU utilization
+
+The Experimenter polls `nvidia-smi` (or the env-appropriate equivalent) periodically while the job runs and records peak/mean GPU utilization. The narrative includes this in the "Training dynamics" section.
+
+If utilization is materially low on a *successful* run (e.g., < 70% mean), the Experimenter's analysis flags it as a potential issue and the `follow_ups` field includes "consider larger batch size to improve MFU" or similar. Low utilization does not by itself trigger a retry on a successful run — the result still counts. It does inform the next experiment's choices.
+
+If utilization is low on a *crashed* run that the Experimenter is otherwise about to retry (e.g., crash was OOM), the fix-and-retry naturally improves utilization (larger effective batch, fewer accumulation micro-steps).
+
+### `torch.compile` cache reuse
+
+If `compile_cache_dir` is set in `config.json`, the Experimenter exports `TORCHINDUCTOR_CACHE_DIR` (or the appropriate env var for the user's compile backend) when launching, pointing at that directory. The cache is shared across experiments to amortize compilation overhead.
+
+**Invalidation rule:** when the experiment's theme is `architecture`, the Experimenter wipes the cache before launching the job (`rm -rf $compile_cache_dir/*`). Architecture changes can invalidate compiled kernels in subtle ways; safer to recompile from scratch.
+
+For other themes (optimizer, augmentation, loss, etc.), the cache is reused as-is. This typically saves 1–10 minutes of compile time per experiment for non-trivial models.
+
+### Proxy-task discipline
+
+The autoresearch loop runs *small* experiments (short steps, single GPU, often a fraction of full training data) as **proxies** for full-scale runs. The real goal is to find improvements that generalize: bigger models, more data, longer training, more compute.
+
+Both the Experimenter and the Reviewer are explicitly prompted on this point. Concretely:
+
+- **Avoid changes that overfit to the proxy.** Regularization tuned specifically for short runs, hyperparameters micro-optimized for the experiment's exact step count, tricks that exploit the val set's specific composition or the random seed — these can show wins at small scale that don't survive scaling. The Experimenter should refuse to recommend such ideas as `accepted` even when val-loss improves; surface them as `inconclusive` with reasoning.
+- **Prefer changes with theoretical or empirical scaling support.** Ideas with a known scaling story (e.g., supported by scaling-law analyses, or with reference implementations validated at multiple scales) are stronger candidates than purely empirical small-scale wins.
+- **Reviewer flags proxy-overfit risk.** When synthesizing insights, the Reviewer specifically tags patterns that look like proxy-overfit (improvements that disappear when combined with other changes, regularization that helps only in this experimental regime, etc.) and adds them to "Anti-patterns" rather than "Patterns observed."
+
+This discipline isn't enforceable mechanically — it's a quality bar baked into the Experimenter and Reviewer system prompts.
+
 ### Subagent hard rules (encoded in each system prompt)
 
 - **Ideator and Reviewer:** no disk writes, no code modifications, no commits. Return structured output only.
 - **Experimenter:**
-    - Writes only to files matching `relevant_files.editable`.
-    - Does not touch `autoresearch/*` tracking files (main agent owns those).
-    - Commits only on the experiment branch. Never commits on trunk.
-    - No `git merge`, `git rebase`, or destructive git ops.
+  - Writes only to files matching `relevant_files.editable`.
+  - Does not touch `autoresearch/*` tracking files (main agent owns those).
+  - Commits only on the experiment branch. Never commits on trunk.
+  - No `git merge`, `git rebase`, or destructive git ops.
 - **Every subagent:**
-    - Must respect all `constraints` from `config.json`.
-    - Must not propose or implement changes that modify validation dataset, validation logic, or validation metrics.
+  - Must respect all `constraints` from `config.json`.
+  - Must not propose or implement changes that modify validation dataset, validation logic, or validation metrics.
 
 ## Files & migration
 
@@ -648,9 +745,9 @@ Thin — orchestration only, no ML-research expertise. Length target: 200–300 
 
 Lengths are approximate upper targets — these don't touch main-agent context, so there's no penalty for depth:
 
-- **`autoresearch-ideator.md`** (~400 lines): research ideation — reading past experiments, evaluating expected impact, hunting for reference implementations, duplicate-checking, writing good rationales, citation-quality rules.
-- **`autoresearch-experimenter.md`** (~600 lines): implementation — localizing code changes, running entrypoints, `Monitor` patterns, crash diagnosis repertoire, fix-per-crash-type playbook, narrative-writing conventions.
-- **`autoresearch-reviewer.md`** (~250 lines): synthesis — efficient scan of N experiment files, pattern identification (not restatement), pruning stale insights, grounding every insight in experiment IDs, strategic-note guidelines.
+- **`autoresearch-ideator.md`** (~400-500 lines): research ideation — reading past experiments, evaluating expected impact, hunting for reference implementations, duplicate-checking, writing good rationales, citation-quality rules, curated source list, proxy-task discipline (don't propose ideas that are likely to be proxy-overfit wins).
+- **`autoresearch-experimenter.md`** (~600-800 lines): implementation — localizing code changes within `editable` globs, running entrypoints (count_params, launch_experiment, read_metrics), `Monitor` patterns, GPU-utilization tracking, `torch.compile` cache reuse and invalidation, crash diagnosis repertoire, fix-per-crash-type playbook, narrative-writing conventions, acceptance-criterion application against current best, proxy-task discipline.
+- **`autoresearch-reviewer.md`** (~300 lines): synthesis — efficient scan of N experiment files, pattern identification (not restatement), pruning stale insights, grounding every insight in experiment IDs, proxy-overfit detection, strategic-note guidelines.
 
 ### Migration from current skill
 

--- a/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-24-autoresearch-redesign-design.md
@@ -110,9 +110,9 @@ Notes on semantics:
 
 - **`relevant_files`** is a hard safety rail for Experimenter. Shell-style globs (`**`, `*`, `?`). Subagents may *edit existing files or create new files* at paths matching `editable`; they may *read* files matching `read_only`; files outside both lists are implicitly off-limits to both reads and writes (other than the standard project-orientation reads like `pyproject.toml` or `README.md`). The constraint is about which paths can be touched, not whether the files preexist.
 - **`entrypoints`** — pluggable user-provided commands. All contracts are documented in SKILL.md (not duplicated per-campaign):
-    - `count_params.command` must print JSON with keys `trainable_params`, `total_params` to stdout.
-    - `launch_experiment.command` must submit a job, print its job ID to stdout, and accept training overrides as positional args. **It must also write final-metrics output that `read_metrics.command` can return.** No agent ever streams stdout/stderr from `launch_experiment.command` into its context — the only path from job to context is via `read_metrics`.
-    - `read_metrics.command` is invoked after the job completes (with `JOB_ID` as an env var) and must print JSON to stdout containing at minimum `{"final_train_loss": float, "final_val_loss": float}`. Other metrics keys (e.g. best-val-loss, GPU utilization) are allowed and surfaced into the experiment file. Implementations: read a metrics file the launcher wrote, query a tracking service (W&B, MLflow), or grep a structured log line.
+  - `count_params.command` must print JSON with keys `trainable_params`, `total_params` to stdout.
+  - `launch_experiment.command` must submit a job, print its job ID to stdout, and accept training overrides as positional args. **It must also write final-metrics output that `read_metrics.command` can return.** No agent ever streams stdout/stderr from `launch_experiment.command` into its context — the only path from job to context is via `read_metrics`.
+  - `read_metrics.command` is invoked after the job completes (with `JOB_ID` as an env var) and must print JSON to stdout containing at minimum `{"final_train_loss": float, "final_val_loss": float}`. Other metrics keys (e.g. best-val-loss, GPU utilization) are allowed and surfaced into the experiment file. Implementations: read a metrics file the launcher wrote, query a tracking service (W&B, MLflow), or grep a structured log line.
 - **`environment`** is a free-form hint string (`"slurm"`, `"local"`, `"k8s"`, `"ray"`, …) that tells the Experimenter which env-specific skill (if any) to invoke for monitoring.
 - **`experiment_budget`** caps each experiment's compute. At least one of `max_steps` or `max_wall_time` (HH:MM:SS) must be set. The `launch_experiment` entrypoint is responsible for honoring these; the Experimenter passes them as overrides if the launcher accepts them, and otherwise relies on the launcher's own defaults. Frozen by constraint after Phase 0 — changing the budget mid-campaign would break experiment comparability.
 - **`compile_cache_dir`** (optional). If set, the Experimenter exports `TORCHINDUCTOR_CACHE_DIR` (or the equivalent env var for the user's compile backend) when launching a job. The cache is shared across experiments for speed; the Experimenter wipes it before launching when `theme: architecture` (architecture changes invalidate compiled kernels). Omit this field if the project doesn't use `torch.compile`.
@@ -677,7 +677,7 @@ For other themes (optimizer, augmentation, loss, etc.), the cache is reused as-i
 
 ### Proxy-task discipline
 
-The autoresearch loop runs *small* experiments (short steps, single GPU, often a fraction of full training data) as **proxies** for full-scale runs. The real goal is to find improvements that generalize: bigger models, more data, longer training, more compute.
+The autoresearch loop runs *small* experiments (small batch sizes, a finite and small number of training steps) as **proxies** for full-scale runs. The real goal is to find faithful improvements for bigger models trained on more data and significantly longer.
 
 Both the Experimenter and the Reviewer are explicitly prompted on this point. Concretely:
 

--- a/docs/superpowers/specs/2026-04-26-getitem-profiler-design.md
+++ b/docs/superpowers/specs/2026-04-26-getitem-profiler-design.md
@@ -100,14 +100,14 @@ Success path:
 {
   "equality": {"passed": true},
   "per_call_wall_time_s": {"mean": 0.0089, "indices": [...]},
-  "delta_vs_baseline": {
-    "per_call_speedup_x": 1.38,
-    "dataloader_speedup_x": 1.12
-  },
+  "delta_vs_baseline":     {"per_call_speedup_x": 1.38, "dataloader_speedup_x": 1.12},
+  "delta_vs_prev_accepted":{"per_call_speedup_x": 1.09, "dataloader_speedup_x": 1.04},
   "line_stats": [...],
   "dataloader_bench": {...}
 }
 ```
+
+`delta_vs_baseline` is the cumulative speedup since session start (informational, surfaced in the final summary). `delta_vs_prev_accepted` is the marginal speedup of *this* edit over the most recent accepted state — this is what the skill's accept/reject decision uses. The harness reads the most recent `measure-N.json` with `equality.passed == true` to compute `delta_vs_prev_accepted`; if no prior accepted measurement exists, "previous accepted" is the baseline.
 
 Equality-failed path:
 ```json
@@ -166,12 +166,12 @@ Per iteration:
    - construct tensors on the right dtype/device once
    - remove redundant copy / `.contiguous()`
    - pre-tokenize / pre-resize at dataset init time
-5. **Apply the edit** (single Edit tool call). Commit on the branch with a message naming the targeted file:line.
+5. **Apply the edit** (single Edit tool call). Do NOT commit yet — measurement runs first, commit only on accept.
 6. **Run `profile_getitem.py measure ...`.** Read the JSON.
-7. **Decision:**
-   - **Equality failed** → `git revert HEAD --no-edit`. Increment consecutive-failure counter. Add the line to the session's failed-attempts set.
-   - **Equality passed but per-call speedup < 1.05×** → same revert path. Threshold is "5% wall-time reduction at the dataset level"; smaller wins are noise.
-   - **Equality passed and speedup ≥ 1.05×** → keep the commit. Reset the consecutive-failure counter. Append an entry to `session.md`. Loop.
+7. **Decision** (using `delta_vs_prev_accepted.per_call_speedup_x`):
+   - **Equality failed** → `git restore <changed_file>` (working-tree revert; nothing to undo in history). Increment consecutive-failure counter. Add the line to the session's failed-attempts set.
+   - **Equality passed but speedup < 1.05× over the previous accepted state** → same `git restore` path. Threshold is "5% wall-time reduction at the dataset level *for this edit*"; smaller wins are noise. Reasoning: comparing each edit against the most recent accepted state (not the original baseline) keeps the bar honest as gains accumulate.
+   - **Equality passed and speedup ≥ 1.05×** → `git add` + commit on the branch with a message naming the targeted file:line. Reset the consecutive-failure counter. Append an entry to `session.md`. Loop.
 
 After termination: print a final summary (starting per-call time, ending per-call time, total speedup, DataLoader throughput before/after, list of accepted commits, list of rejected lines). The branch is left for the user to merge or discard.
 
@@ -212,7 +212,7 @@ After termination: print a final summary (starting per-call time, ending per-cal
 1. Re-import factory (after Claude's edit), instantiate.
 2. **Equality check first** (fail-fast): for each cached index, seed, call `dataset[i]`, compare to the pickled baseline output via the equality function. On mismatch, write `measure-N.json` with the failed shape and exit 0. (Default equality: recursive walker over dicts/lists/tuples; `torch.equal` for tensors; `np.array_equal` for arrays; `tobytes()` byte-equal for PIL Images. Override via `--equality-fn pkg.mod:fn`.)
 3. If equality passes, repeat the line-profiler + DataLoader bench from `baseline`.
-4. Compute `delta_vs_baseline` against the cached `baseline.json`.
+4. Compute `delta_vs_baseline` against `baseline.json`, and `delta_vs_prev_accepted` against the most recent `measure-K.json` with `equality.passed == true` (or `baseline.json` if there's no prior accepted measurement).
 5. Write `measure-N.json`.
 
 ### Failure modes the harness handles itself

--- a/docs/superpowers/specs/2026-04-26-getitem-profiler-design.md
+++ b/docs/superpowers/specs/2026-04-26-getitem-profiler-design.md
@@ -96,6 +96,7 @@ Written by `profile_getitem.py baseline`. Read by the skill once at session star
 Written by `profile_getitem.py measure`. `N` auto-increments per session. Read by the skill after each edit.
 
 Success path:
+
 ```json
 {
   "equality": {"passed": true},
@@ -110,6 +111,7 @@ Success path:
 `delta_vs_baseline` is the cumulative speedup since session start (informational, surfaced in the final summary). `delta_vs_prev_accepted` is the marginal speedup of *this* edit over the most recent accepted state — this is what the skill's accept/reject decision uses. The harness reads the most recent `measure-N.json` with `equality.passed == true` to compute `delta_vs_prev_accepted`; if no prior accepted measurement exists, "previous accepted" is the baseline.
 
 Equality-failed path:
+
 ```json
 {
   "equality": {
@@ -184,6 +186,7 @@ After termination: print a final summary (starting per-call time, ending per-cal
 3. **Cache outputs:** pickle each output to `<out-dir>/baseline/<i>.pkl`.
 4. **Per-call wall time:** time each `dataset[i]` call (also under seed reset), record mean + per-index list. If mean < ~1 ms, set `reliable_line_stats: false`.
 5. **Line profiling** — programmatic API (NOT `autoprofile.run` / `kernprof`):
+
    ```python
    from line_profiler import LineProfiler
    from line_profiler.scoping_policy import ScopingPolicy
@@ -203,6 +206,7 @@ After termination: print a final summary (starting per-call time, ending per-cal
    prof.disable_by_count()
    stats = prof.get_stats()
    ```
+
    `add_class` walks methods defined on the class. `add_module` picks up module-level helpers. `ScopingPolicy.LOCAL` keeps the profiler from recursing into third-party imports. `wrap=True` replaces methods so calls through the C-level `__getitem__` slot still hit the profiler.
 6. **DataLoader benchmark:** wrap the dataset in `DataLoader(batch_size=B, num_workers=W)`, iterate `bench-batches` batches, drop the first batch (worker-warmup), record batches/sec + mean batch latency.
 7. Write `baseline.json`.

--- a/docs/superpowers/specs/2026-04-26-getitem-profiler-design.md
+++ b/docs/superpowers/specs/2026-04-26-getitem-profiler-design.md
@@ -1,0 +1,294 @@
+# `getitem-profiler` skill — design
+
+Date: 2026-04-26
+Issue: #4
+Status: spec drafted, awaiting user review
+
+## Motivation
+
+`Dataset.__getitem__` is a common dataloader bottleneck. Optimizing it is mechanical work — profile, find the slowest line, rewrite it, verify the rewrite preserves outputs and actually saves time, repeat — but doing it by hand is tedious and easy to get wrong (e.g., introducing caching that breaks correctness, accepting an "improvement" that's just measurement noise, missing that the win disappears under multi-worker DataLoader IPC).
+
+This skill automates that loop on a side branch, with two safety nets baked in: every edit must produce byte-identical outputs against a cached baseline (under seeded RNGs), and every edit must deliver a meaningful per-call speedup. Failed edits revert automatically; the user reviews the resulting branch as a single object at the end.
+
+## Constraints
+
+- **Runs inside Claude Code** as a skill in the `ml-research` plugin. Same shape as the other skills: thin SKILL.md prompt + a Python helper script for the deterministic, measurable work.
+- **Single-process, in-process measurement.** Profiling uses `line_profiler` programmatically against a live dataset instance — not via `kernprof` against a launched script. A short `DataLoader(num_workers>0)` micro-benchmark serves as a reality check after each accepted edit.
+- **Multi-rank distributed profiling is out of scope**, mention-only. Wins should generally hold across ranks since each rank's workers are independent.
+- **Autonomous on a side branch.** No per-edit user confirmation. Equality + speedup checks gate every commit; rejected edits auto-revert.
+- **Determinism via seeded RNGs**, not `torch.use_deterministic_algorithms(True)` or env-var gymnastics. `torch.manual_seed`, `np.random.seed`, `random.seed` are reset before every `dataset[i]` call. If outputs still aren't reproducible under that, the skill bails out rather than silently relaxing equality.
+
+## Architecture
+
+```
+plugins/ml-research/skills/getitem-profiler/
+├── SKILL.md                  # orchestration prompt (~150-200 lines)
+└── scripts/
+    └── profile_getitem.py    # measurement harness, JSON in/out
+```
+
+**Two actors:**
+
+| Actor | Owns |
+|---|---|
+| **Skill (Claude)** | Greedy edit loop on a side branch. Picks slowest line, reads surrounding code, proposes one edit, applies it, invokes the harness, accepts or reverts based on the JSON. Stops on diminishing returns / consecutive failures / user interrupt. Writes a one-line entry to `session.md` per accepted edit. |
+| **Harness (`profile_getitem.py`)** | The only thing that touches the user's dataset. Instantiates from a factory function, seeds RNGs around each call, runs `line_profiler` on `__getitem__` + auto-discovered subfunctions, runs the DataLoader micro-benchmark, dumps/compares cached baseline outputs, prints a JSON report. Pure measurement; no edits, no judgment. |
+
+The harness is a single CLI with two subcommands:
+
+```
+profile_getitem.py baseline --factory pkg.mod:make_dataset \
+    [--num-indices N] [--indices "0,1,2,..."] \
+    [--profile-scope {local,package}] \
+    [--num-workers W] [--bench-batches B] \
+    [--equality-fn pkg.mod:fn] \
+    [--out-dir DIR]
+
+profile_getitem.py measure  --factory pkg.mod:make_dataset \
+    --baseline-dir DIR
+```
+
+`baseline` runs once at session start (caches outputs, records starting timings). `measure` runs after each Claude edit (re-runs the same indices, checks equality against the cached outputs, returns per-line timings + DataLoader bench).
+
+The cache lives in `.getitem-profile/` by default and is gitignored. The skill ensures `.getitem-profile/` is in `.gitignore` at session start.
+
+## Data model
+
+### `baseline.json`
+
+Written by `profile_getitem.py baseline`. Read by the skill once at session start.
+
+```json
+{
+  "factory": "pkg.mod:make_dataset",
+  "indices": [0, 1, 2, 3, 4, 5, 6, 7],
+  "seed_base": 0,
+  "equality_mode": "strict",
+  "reliable_line_stats": true,
+  "per_call_wall_time_s": {"mean": 0.0123, "indices": [0.0119, 0.0124, ...]},
+  "line_stats": [
+    {
+      "file": "mypkg/dataset.py",
+      "function": "MyDataset.__getitem__",
+      "line": 42,
+      "code": "img = Image.open(path).convert(\"RGB\")",
+      "hits": 8,
+      "time_s": 0.080,
+      "pct": 65.1
+    }
+  ],
+  "dataloader_bench": {
+    "num_workers": 4,
+    "batch_size": 16,
+    "batches_measured": 50,
+    "batches_per_sec": 12.3,
+    "mean_batch_latency_s": 0.081
+  }
+}
+```
+
+`equality_mode` is `strict` in the normal case. The harness sets it to `non_deterministic` (and refuses to proceed past baseline) if calling `dataset[i]` twice with the same seed already produces different outputs — see "Edge cases" below.
+
+`reliable_line_stats` is `false` if mean per-call time is below ~1 ms, signaling that line_profiler overhead dominates rankings.
+
+### `measure-N.json`
+
+Written by `profile_getitem.py measure`. `N` auto-increments per session. Read by the skill after each edit.
+
+Success path:
+```json
+{
+  "equality": {"passed": true},
+  "per_call_wall_time_s": {"mean": 0.0089, "indices": [...]},
+  "delta_vs_baseline": {
+    "per_call_speedup_x": 1.38,
+    "dataloader_speedup_x": 1.12
+  },
+  "line_stats": [...],
+  "dataloader_bench": {...}
+}
+```
+
+Equality-failed path:
+```json
+{
+  "equality": {
+    "passed": false,
+    "first_diff_path": "outputs[0]['image']",
+    "summary": "tensor shape (3,224,224) vs (3,225,225)"
+  }
+}
+```
+
+Exceptions during `dataset[i]` are reported through the same equality-failed shape (`"summary": "raised RuntimeError: ..."`). DataLoader benchmark failures (worker death, introduced pickling error) likewise surface as a failed measurement; no special status — failure is failure.
+
+### `.getitem-profile/session.md`
+
+Skill-maintained narrative artifact. One entry per accepted edit:
+
+```markdown
+## Edit 1 — Replace PIL.Image.open with torchvision.io.read_image
+- target: mypkg/dataset.py:42 (was 65.1% of __getitem__)
+- per-call: 12.3 ms → 8.9 ms (1.38x)
+- dataloader: 12.3 batches/s → 13.8 batches/s (1.12x)
+- commit: a1b2c3d
+```
+
+Plus a header listing the rejected attempts (target line + brief reason). The user reads this at the end to understand what the branch contains.
+
+## Phase 0: Setup (once per session)
+
+1. The skill confirms with the user:
+   - factory path (`pkg.mod:make_dataset`)
+   - `--num-indices` (default 8)
+   - `--profile-scope` (default `local` — only the dataset class + its defining module; `package` walks sibling modules in the same top-level package, for projects whose transforms / IO helpers live there)
+   - `--num-workers` for the DataLoader bench (default 4)
+2. Add `.getitem-profile/` to `.gitignore` if not already present.
+3. Create the side branch `getitem-profile/<dataset-slug>-<YYYYMMDD-HHMM>` off the user's current `HEAD`.
+4. Run `profile_getitem.py baseline ...`.
+5. Read `baseline.json`. If `equality_mode == "non_deterministic"` or `reliable_line_stats == false`, stop and surface the issue (see "Edge cases"). Otherwise, show the user a brief table of the top-5 slowest lines + baseline DataLoader throughput so they know what we're starting with.
+
+## Phase 1: Greedy loop
+
+Per iteration:
+
+1. **Pick the next-slowest line** in `__getitem__` or a discovered subfunction that hasn't already been the target of a failed attempt this session.
+2. **Termination checks:**
+   - If the targeted line's `pct` is < 5% of `__getitem__` total → stop (diminishing returns).
+   - If we've had 3 consecutive failed attempts → stop.
+   - If the user has interrupted → stop.
+3. **Read just enough** surrounding code: the function it's in, ~20 lines of context, and any helper it calls. Don't read the whole module.
+4. **Propose one concrete edit.** SKILL.md enumerates common-win categories as a vocabulary (not a checklist):
+   - vectorize a Python loop into numpy/torch ops
+   - replace PIL with `cv2` or `torchvision.io` for decode
+   - cache an expensive constant in `__init__`
+   - replace per-call file open with mmap or a pre-indexed handle
+   - construct tensors on the right dtype/device once
+   - remove redundant copy / `.contiguous()`
+   - pre-tokenize / pre-resize at dataset init time
+5. **Apply the edit** (single Edit tool call). Commit on the branch with a message naming the targeted file:line.
+6. **Run `profile_getitem.py measure ...`.** Read the JSON.
+7. **Decision:**
+   - **Equality failed** → `git revert HEAD --no-edit`. Increment consecutive-failure counter. Add the line to the session's failed-attempts set.
+   - **Equality passed but per-call speedup < 1.05×** → same revert path. Threshold is "5% wall-time reduction at the dataset level"; smaller wins are noise.
+   - **Equality passed and speedup ≥ 1.05×** → keep the commit. Reset the consecutive-failure counter. Append an entry to `session.md`. Loop.
+
+After termination: print a final summary (starting per-call time, ending per-call time, total speedup, DataLoader throughput before/after, list of accepted commits, list of rejected lines). The branch is left for the user to merge or discard.
+
+## Helper script (`profile_getitem.py`)
+
+### `baseline` subcommand
+
+1. Import factory (`importlib.import_module` + `getattr`), call it, get `dataset`.
+2. **Determinism self-check:** for each index, seed RNGs (`torch.manual_seed`, `np.random.seed`, `random.seed` with `seed_base + i`), call `dataset[i]`, pickle the output. Then re-seed and re-call. If the second output doesn't equal the first, set `equality_mode: non_deterministic`, write `baseline.json` with `first_diff_path`, exit 0 (the skill handles the non-deterministic case).
+3. **Cache outputs:** pickle each output to `<out-dir>/baseline/<i>.pkl`.
+4. **Per-call wall time:** time each `dataset[i]` call (also under seed reset), record mean + per-index list. If mean < ~1 ms, set `reliable_line_stats: false`.
+5. **Line profiling** — programmatic API (NOT `autoprofile.run` / `kernprof`):
+   ```python
+   from line_profiler import LineProfiler
+   from line_profiler.scoping_policy import ScopingPolicy
+
+   prof = LineProfiler()
+   prof.add_class(type(dataset), scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+   prof.add_module(sys.modules[type(dataset).__module__],
+                   scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+   if profile_scope == "package":
+       for sibling in walk_sibling_modules(type(dataset).__module__):
+           prof.add_module(sibling, scoping_policy=ScopingPolicy.LOCAL, wrap=True)
+
+   prof.enable_by_count()
+   for i in indices:
+       seed_all(seed_base + i)
+       _ = dataset[i]
+   prof.disable_by_count()
+   stats = prof.get_stats()
+   ```
+   `add_class` walks methods defined on the class. `add_module` picks up module-level helpers. `ScopingPolicy.LOCAL` keeps the profiler from recursing into third-party imports. `wrap=True` replaces methods so calls through the C-level `__getitem__` slot still hit the profiler.
+6. **DataLoader benchmark:** wrap the dataset in `DataLoader(batch_size=B, num_workers=W)`, iterate `bench-batches` batches, drop the first batch (worker-warmup), record batches/sec + mean batch latency.
+7. Write `baseline.json`.
+
+### `measure` subcommand
+
+1. Re-import factory (after Claude's edit), instantiate.
+2. **Equality check first** (fail-fast): for each cached index, seed, call `dataset[i]`, compare to the pickled baseline output via the equality function. On mismatch, write `measure-N.json` with the failed shape and exit 0. (Default equality: recursive walker over dicts/lists/tuples; `torch.equal` for tensors; `np.array_equal` for arrays; `tobytes()` byte-equal for PIL Images. Override via `--equality-fn pkg.mod:fn`.)
+3. If equality passes, repeat the line-profiler + DataLoader bench from `baseline`.
+4. Compute `delta_vs_baseline` against the cached `baseline.json`.
+5. Write `measure-N.json`.
+
+### Failure modes the harness handles itself
+
+- Factory raises → exit non-zero with a structured error JSON (skill surfaces to user; can't proceed).
+- Dataset's `__getitem__` raises during measurement → equality-failed shape with `summary: "raised <ExcType>: <msg>"`.
+- Output unpicklable → equality-failed shape with `summary: "output not picklable: ..."`.
+- DataLoader bench fails (worker dies, introduced pickling error) → equality-failed shape, since "the change broke things" is the same outcome from the loop's perspective.
+
+## Edge cases
+
+**Dataset is non-deterministic under seeded RNGs.** `baseline` detects this via its own re-call equality check. The skill refuses to start the greedy loop, names the leaf that differs, and offers two paths: (1) supply `--equality-fn` that tolerates the non-determinism, (2) bail out. No silent fall-back to tolerance.
+
+**`__getitem__` is too fast to profile reliably.** If baseline mean per-call wall time < ~1 ms, line_profiler overhead dominates rankings. `reliable_line_stats: false` in `baseline.json`; skill refuses to start the loop and tells the user the dataset is already fast.
+
+**Edit makes `__getitem__` raise.** Treated as a failed equality check (exception captured in `summary`). Revert + counter increment.
+
+**Edit is a no-op or correct refactor with no measurable speedup.** Falls under the < 1.05× rule → reverted. Prevents commits that don't pull their weight.
+
+**Multiple lines tie for slowest.** Take the highest-line-number one. Arbitrary but deterministic.
+
+**Auto-discovered subfunction is in a path the user didn't intend to be editable.** Can happen with `--profile-scope=package`. The skill checks each prospective edit's path against the dataset module's directory + sibling modules in the same top-level package; if the slowest line is outside that scope, the skill notes it and moves to the next-slowest line. The user can opt in to broader edit scope by re-invoking with explicit broadening.
+
+**Caching across calls is a tempting trap.** An optimization that mutates dataset state across calls (e.g., memoizing `__getitem__` results) can pass the per-index equality check while corrupting batch-level behavior under DataLoader (workers fork the dataset; cross-worker cache state diverges silently). SKILL.md names this trap explicitly and forbids edits that introduce mutable cross-call state.
+
+**Resumption after interruption.** If a session is interrupted (token limit, `/compact`, machine reboot) and the user re-invokes the skill: it detects an existing `.getitem-profile/` dir + `getitem-profile/...` branch, reads `session.md` to recover the failed-attempts set and accepted edits, and resumes the loop without re-baselining. Cached outputs and `baseline.json` remain authoritative.
+
+**Cleanup.** `.getitem-profile/` is gitignored. The branch is left for the user — the skill never deletes it.
+
+## Hard rules (encoded in SKILL.md)
+
+- Edits only inside the dataset class / its module / its sibling modules in the same top-level package, scoped by `--profile-scope`. Never broaden silently.
+- Never introduce mutable cross-call state (see "Caching trap" above).
+- Never modify validation code or any code path outside `__getitem__`'s call graph.
+- One edit per commit. No bundling — defeats per-line attribution.
+- All edits on the side branch only. Never touch `main` or the user's prior branch.
+
+## Caveat layer (surfaced to the user at start AND end of session)
+
+> Per-call timings come from in-process measurement; under a real DataLoader, fixed costs (worker startup, IPC, fork-time imports) won't show up here. The DataLoader micro-benchmark gives a sanity check, but wins below ~50 µs per call may not translate. Wins should generally hold across distributed ranks since each rank's workers are independent.
+
+## Files
+
+### Plugin-shipped
+
+```
+plugins/ml-research/skills/getitem-profiler/
+├── SKILL.md                  # ~150-200 lines; orchestration prompt
+└── scripts/
+    └── profile_getitem.py    # measurement harness
+```
+
+### User-provided
+
+- A factory function `pkg.mod:make_dataset` returning a ready dataset instance. Documented one-liner template in SKILL.md.
+- Optional `--equality-fn pkg.mod:fn` for exotic outputs (bounding boxes where order doesn't matter, etc.).
+
+### Session-scoped (gitignored)
+
+```
+.getitem-profile/
+├── baseline.json
+├── baseline/
+│   ├── 0.pkl
+│   ├── 1.pkl
+│   └── ...
+├── measure-1.json
+├── measure-2.json
+├── ...
+└── session.md
+```
+
+## Out of scope
+
+- **Multi-rank / multi-node distributed profiling.** Mentioned in the caveat layer; not measured.
+- **Memory profiling.** Wall time only.
+- **Optimizing DataLoader-level parameters** (num_workers, pin_memory, prefetch_factor, persistent_workers). The skill measures one DataLoader configuration at user request; it doesn't sweep.
+- **Optimizing collate functions or transforms not invoked from `__getitem__`.** Out-of-scope by construction — `__getitem__` is the entry point.
+- **Per-edit user confirmation.** Autonomous on the side branch is the design choice; user reviews at the end.

--- a/plugins/ml-research/skills/autoresearch/SKILL.md
+++ b/plugins/ml-research/skills/autoresearch/SKILL.md
@@ -31,10 +31,17 @@ All work happens in a dedicated worktree at `../autoresearch` (`git worktree add
 
 ## Procedure
 
-Each experiment runs on a single A100 for up to 45 min via `${CLAUDE_SKILL_DIR}/scripts/launch.sbatch`. The launch script sets `config/conf.yaml` as the base; the caller must layer `${CLAUDE_SKILL_DIR}/config.yaml` on top (1 epoch, no checkpointing, reduced val batches, 30-min timer, W&B `autoresearch` tag). Override further with additional CLI args (later `--config=` values override earlier ones):
+Each experiment runs on a single A100 for up to 45 min via `${CLAUDE_SKILL_DIR}/scripts/launch.sbatch`. The launch script sets `config/conf.yaml` as the base; the caller must layer `${CLAUDE_SKILL_DIR}/config.yaml` on top (1 epoch, no checkpointing, reduced val batches, 30-min timer, W&B `autoresearch` tag). The script reads three caller-supplied values (none are hardcoded):
+
+- `--account=...` on the sbatch CLI — the SLURM account to charge (e.g. `<project>-delta-gpu`).
+- `AUTORESEARCH_DATA_DIR` env var — dataset root, used to build `--data.mdata_path` and `--data.gtf_path`.
+- `AUTORESEARCH_SCRATCH_ROOT` env var — per-user scratch root; the job creates `$AUTORESEARCH_SCRATCH_ROOT/$SLURM_JOB_ID` as its working dir and exports it as `$TMPDIR`.
+
+Export these once per shell (e.g. in `~/.bashrc`) so you don't have to re-supply them each submit. Override further via CLI args after the config (later `--config=` values override earlier ones):
 
 ```bash
-sbatch "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
+sbatch --account=<project>-delta-gpu \
+  "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
   --config="${CLAUDE_SKILL_DIR}/config.yaml" \
   --model.lr=3e-4
 ```
@@ -71,9 +78,10 @@ Each file has a single responsibility — do not duplicate information across fi
 3. Branch: `git checkout -b autoresearch/experiments/NNN-description`.
 4. Implement the changes.
 5. Verify param budget with `count_params.py`.
-6. Use the slurm skill to select the best partition, then submit:
+6. Use the slurm skill to select the best partition, then submit (assumes `AUTORESEARCH_DATA_DIR` and `AUTORESEARCH_SCRATCH_ROOT` are exported):
    ```sh
-   sbatch --partition=<selected> "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
+   sbatch --account=<account> --partition=<selected> \
+     "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
      --config="${CLAUDE_SKILL_DIR}/config.yaml" \
      --trainer.logger.init_args.name="$(git branch --show-current)" \
      --trainer.logger.init_args.notes="One-sentence summary of the change"

--- a/plugins/ml-research/skills/autoresearch/SKILL.md
+++ b/plugins/ml-research/skills/autoresearch/SKILL.md
@@ -7,10 +7,7 @@ Goal: iterate autonomously and indefinitely on model architecture, data augmenta
 
 ## Scope
 
-You may change architecture, data augmentation, training loop, objective function, hyperparameters, etc. Key code paths:
-
-- `metabolo_genes/models/single_cell.py` (architecture, training loop, objective)
-- `metabolo_genes/data/single_cell.py` (data augmentation)
+You may change architecture, data augmentation, training loop, objective function, hyperparameters, etc. At the start of each session, identify the project's model and data modules (confirm with the user if ambiguous) — typically the `LightningModule` subclass referenced by `config/conf.yaml`'s `model.class_path` and the data-augmentation code in the corresponding `LightningDataModule`.
 
 **Do not** modify:
 
@@ -31,20 +28,21 @@ All work happens in a dedicated worktree at `../autoresearch` (`git worktree add
 
 ## Procedure
 
-Each experiment runs on a single A100 for up to 45 min via `${CLAUDE_SKILL_DIR}/scripts/launch.sbatch`. The launch script sets `config/conf.yaml` as the base; the caller must layer `${CLAUDE_SKILL_DIR}/config.yaml` on top (1 epoch, no checkpointing, reduced val batches, 30-min timer, W&B `autoresearch` tag). The script reads three caller-supplied values (none are hardcoded):
+Each experiment runs on a single A100 for up to 45 min via `${CLAUDE_SKILL_DIR}/scripts/launch.sbatch`. The launch script sets `config/conf.yaml` as the base; the caller layers `${CLAUDE_SKILL_DIR}/config.yaml` on top (1 epoch, reduced val batches, 30-min timer, learning-rate monitor). The script reads two caller-supplied values (nothing is hardcoded to a specific project):
 
-- `--account=...` on the sbatch CLI — the SLURM account to charge (e.g. `<project>-delta-gpu`).
-- `AUTORESEARCH_DATA_DIR` env var — dataset root, used to build `--data.mdata_path` and `--data.gtf_path`.
+- `--account=...` on the sbatch CLI — the SLURM account to charge (e.g. `<project>-delta-gpu` on Delta).
 - `AUTORESEARCH_SCRATCH_ROOT` env var — per-user scratch root; the job creates `$AUTORESEARCH_SCRATCH_ROOT/$SLURM_JOB_ID` as its working dir and exports it as `$TMPDIR`.
 
-Export these once per shell (e.g. in `~/.bashrc`) so you don't have to re-supply them each submit. Override further via CLI args after the config (later `--config=` values override earlier ones):
+Any data paths, model overrides, or logger settings are passed as additional CLI args after the config (later `--config=` values override earlier ones). Export `AUTORESEARCH_SCRATCH_ROOT` once per shell (e.g. in `~/.bashrc`) so you don't re-supply it each submit:
 
 ```bash
-sbatch --account=<project>-delta-gpu \
+sbatch --account=<slurm-account> \
   "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
   --config="${CLAUDE_SKILL_DIR}/config.yaml" \
   --model.lr=3e-4
 ```
+
+To tag experiments launched via this skill (recommended, makes them filterable in your tracker), append `--trainer.logger.init_args.tags+=[autoresearch]` — or whatever syntax your logger/jsonargparse combination uses for list-append.
 
 Run `uv run harness fit --help` for docs on available overrides.
 
@@ -78,7 +76,7 @@ Each file has a single responsibility — do not duplicate information across fi
 3. Branch: `git checkout -b autoresearch/experiments/NNN-description`.
 4. Implement the changes.
 5. Verify param budget with `count_params.py`.
-6. Use the slurm skill to select the best partition, then submit (assumes `AUTORESEARCH_DATA_DIR` and `AUTORESEARCH_SCRATCH_ROOT` are exported):
+6. Use the slurm skill to select the best partition, then submit (assumes `AUTORESEARCH_SCRATCH_ROOT` is exported):
    ```sh
    sbatch --account=<account> --partition=<selected> \
      "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \

--- a/plugins/ml-research/skills/autoresearch/config.yaml
+++ b/plugins/ml-research/skills/autoresearch/config.yaml
@@ -1,5 +1,12 @@
-# Overrides for autoresearch quick experiments (single GPU, ~30 min).
-# Layered on top of conf.yaml via: --config=config/conf.yaml --config=config/autoresearch.yaml
+# Autoresearch quick-experiment overrides. Layered on top of the project's
+# base config via:
+#   --config=config/conf.yaml --config=${CLAUDE_SKILL_DIR}/config.yaml
+#
+# Contains only project-agnostic scaffolding (short run, reduced val, a hard
+# timer). The base config is responsible for logger, data, model, and any
+# project-specific callbacks. To tag experiments launched via this config,
+# append `--trainer.logger.init_args.tags+=[autoresearch]` (or equivalent)
+# to the sbatch invocation.
 trainer:
   max_epochs: 1
   limit_val_batches: 50
@@ -9,14 +16,7 @@ trainer:
       init_args:
         logging_interval: step
         log_momentum: true
-    - class_path: metabolo_genes.harness.callbacks.ExceptionCallback
     - class_path: lightning.pytorch.callbacks.Timer
       init_args:
         duration: 00:00:30:00
         interval: step
-  logger:
-    class_path: lightning.pytorch.loggers.WandbLogger
-    init_args:
-      project: expression_prediction
-      tags:
-        - autoresearch

--- a/plugins/ml-research/skills/autoresearch/scripts/count_params.py
+++ b/plugins/ml-research/skills/autoresearch/scripts/count_params.py
@@ -1,15 +1,15 @@
 import json
 from pathlib import Path
 
+import lightning.pytorch as pl
 import torch
 import yaml
 from jsonargparse import ArgumentParser, Namespace
-from metabolo_genes.models.single_cell import SingleCellModel
 
 
 def main(config_path: Path = Path("config", "conf.yaml")) -> None:
     parser = ArgumentParser()
-    parser.add_class_arguments(SingleCellModel, "model")
+    parser.add_subclass_arguments(pl.LightningModule, "model")
 
     with config_path.open() as f:
         raw = yaml.safe_load(f)
@@ -18,7 +18,10 @@ def main(config_path: Path = Path("config", "conf.yaml")) -> None:
 
     with torch.device("meta"):
         model = parser.instantiate_classes(cfg).model
-        model.build_model()
+        # Some projects defer parameter materialization to a `build_model`
+        # method; call it if present, otherwise the model is already built.
+        if hasattr(model, "build_model"):
+            model.build_model()
 
     num_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
     num_total = sum(p.numel() for p in model.parameters())

--- a/plugins/ml-research/skills/autoresearch/scripts/launch.sbatch
+++ b/plugins/ml-research/skills/autoresearch/scripts/launch.sbatch
@@ -1,6 +1,5 @@
 #!/bin/bash
 #SBATCH --job-name=autoresearch
-#SBATCH --account=bdhi-delta-gpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=5
@@ -10,11 +9,25 @@
 #SBATCH --output=logs/%x/%j/%t/stdout.log
 #SBATCH --error=logs/%x/%j/%t/stderr.log
 
+# Account and data paths are not hardcoded — the caller must supply them:
+#   --account=<slurm-account>   passed to sbatch on the CLI
+#   AUTORESEARCH_DATA_DIR       env var, inherited by the job
+#   AUTORESEARCH_SCRATCH_ROOT   env var, inherited by the job
+# Example:
+#   AUTORESEARCH_DATA_DIR=/work/hdd/<project>/$USER/data \
+#   AUTORESEARCH_SCRATCH_ROOT=/work/hdd/<project>/$USER \
+#   sbatch --account=<project>-delta-gpu --partition=<p> \
+#     "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
+#     --config="${CLAUDE_SKILL_DIR}/config.yaml"
+
 set -euo pipefail
 
-DATA_DIR=/work/hdd/bdhi/$USER/data
-JOB_DIR=/work/hdd/bdhi/$USER/$SLURM_JOB_ID
-mkdir -p $JOB_DIR
+: "${AUTORESEARCH_DATA_DIR:?AUTORESEARCH_DATA_DIR must be set (dataset root)}"
+: "${AUTORESEARCH_SCRATCH_ROOT:?AUTORESEARCH_SCRATCH_ROOT must be set (per-user scratch root; job dir is created beneath it as \$SLURM_JOB_ID)}"
+
+DATA_DIR="$AUTORESEARCH_DATA_DIR"
+JOB_DIR="$AUTORESEARCH_SCRATCH_ROOT/$SLURM_JOB_ID"
+mkdir -p "$JOB_DIR"
 
 export TMPDIR=$JOB_DIR
 

--- a/plugins/ml-research/skills/autoresearch/scripts/launch.sbatch
+++ b/plugins/ml-research/skills/autoresearch/scripts/launch.sbatch
@@ -9,48 +9,47 @@
 #SBATCH --output=logs/%x/%j/%t/stdout.log
 #SBATCH --error=logs/%x/%j/%t/stderr.log
 
-# Account and data paths are not hardcoded — the caller must supply them:
-#   --account=<slurm-account>   passed to sbatch on the CLI
-#   AUTORESEARCH_DATA_DIR       env var, inherited by the job
-#   AUTORESEARCH_SCRATCH_ROOT   env var, inherited by the job
+# Assumes a Lightning-CLI-style project with:
+#   - `uv run harness fit` as the training entrypoint
+#   - a base config at `config/conf.yaml`
+#   - `scripts/torch.env` providing CUDA / NCCL env vars
+# Fork this script if your project deviates.
+#
+# Caller must supply:
+#   --account=<slurm-account>    on the sbatch CLI
+#   AUTORESEARCH_SCRATCH_ROOT    env var, per-user scratch root (job dir is
+#                                 created beneath it as $SLURM_JOB_ID and
+#                                 exported as $TMPDIR)
+#   + any data / model / logger overrides, passed as positional args.
+#
 # Example:
-#   AUTORESEARCH_DATA_DIR=/work/hdd/<project>/$USER/data \
 #   AUTORESEARCH_SCRATCH_ROOT=/work/hdd/<project>/$USER \
-#   sbatch --account=<project>-delta-gpu --partition=<p> \
+#   sbatch --account=<account> --partition=<p> \
 #     "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
-#     --config="${CLAUDE_SKILL_DIR}/config.yaml"
+#     --config="${CLAUDE_SKILL_DIR}/config.yaml" \
+#     --data.path=/path/to/dataset
 
 set -euo pipefail
 
-: "${AUTORESEARCH_DATA_DIR:?AUTORESEARCH_DATA_DIR must be set (dataset root)}"
 : "${AUTORESEARCH_SCRATCH_ROOT:?AUTORESEARCH_SCRATCH_ROOT must be set (per-user scratch root; job dir is created beneath it as \$SLURM_JOB_ID)}"
 
-DATA_DIR="$AUTORESEARCH_DATA_DIR"
 JOB_DIR="$AUTORESEARCH_SCRATCH_ROOT/$SLURM_JOB_ID"
 mkdir -p "$JOB_DIR"
-
-export TMPDIR=$JOB_DIR
+export TMPDIR="$JOB_DIR"
 
 declare -a FIT_ARGS=(
     --seed_everything=42 \
     --config=config/conf.yaml \
     --trainer.num_nodes=$SLURM_NNODES \
     --trainer.devices=$SLURM_NTASKS_PER_NODE \
-    --data.mdata_path=$DATA_DIR/combined.h5mu \
-    --data.gtf_path=$DATA_DIR/gencode.vM25.annotation.gtf \
     --trainer.default_root_dir=$JOB_DIR \
     --trainer.logger.init_args.save_dir=$JOB_DIR \
-    --trainer.logger.init_args.id=$SLURM_JOB_ID \
     --data.num_workers=4 \
     --data.prefetch_factor=4
 )
 
-# Caller supplies the plugin-bundled config override (and any other layered
-# configs or arg overrides) via positional args. Because $@ is appended after
-# FIT_ARGS, later --config files override earlier ones. Example invocation:
-#   sbatch "${CLAUDE_SKILL_DIR}/scripts/launch.sbatch" \
-#     --config="${CLAUDE_SKILL_DIR}/config.yaml" \
-#     --trainer.max_epochs=50
+# Caller-supplied args (plugin config, data paths, model/logger overrides)
+# come last so they override FIT_ARGS via later-wins config layering.
 FIT_ARGS+=("$@")
 
 srun -l uv run --env-file=scripts/torch.env harness fit "${FIT_ARGS[@]}"

--- a/plugins/ml-research/skills/getitem-profiler/SKILL.md
+++ b/plugins/ml-research/skills/getitem-profiler/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: getitem-profiler
+description: Profile Dataset.__getitem__ with line_profiler and greedily optimize the slowest line on a side branch, gated by output equality and a per-call speedup threshold. Use when the user says "__getitem__ is slow", "profile my dataset", "speed up my dataloader", or supplies a factory function and asks for optimization.
+---
+
+(Body filled in by Task 4.)

--- a/plugins/ml-research/skills/getitem-profiler/SKILL.md
+++ b/plugins/ml-research/skills/getitem-profiler/SKILL.md
@@ -31,7 +31,7 @@ Then:
 3. Run `python scripts/profile_getitem.py baseline --factory <factory> --num-indices <N> --profile-scope <scope> --num-workers <W> --bench-batches <B> --out-dir .getitem-profile/`.
 4. Read `.getitem-profile/baseline.json`.
 5. Bail if either:
-   - `equality_mode == "non_deterministic"` — surface the `first_diff_path` to the user, name the leaf that differs, offer two paths: (a) supply `--equality-fn pkg.mod:fn` that tolerates the non-determinism, (b) bail. Never silently fall back to tolerance.
+   - `equality_mode == "non_deterministic"` — surface the `first_diff_path` to the user, name the leaf that differs, and bail. The harness is strict-equality only. The user's options are: (a) seed any non-standard randomness sources in `__init__` so `torch.manual_seed`/`np.random.seed`/`random.seed` cover the call, then re-run; (b) wrap the dataset in a deterministic shim and point `--factory` at the shim; (c) accept that this dataset isn't a candidate for the harness.
    - `reliable_line_stats == false` — tell the user the dataset is already fast (mean per-call < ~1 ms); wins here would be in the noise.
 6. Otherwise, show the user a brief table of the top-5 slowest lines + the baseline DataLoader throughput so they know the starting point.
 

--- a/plugins/ml-research/skills/getitem-profiler/SKILL.md
+++ b/plugins/ml-research/skills/getitem-profiler/SKILL.md
@@ -19,15 +19,16 @@ Confirm with the user:
        from mypkg.dataset import MyDataset
        return MyDataset(root="/path", split="train", transform=...)
    ```
-2. **`--num-indices`** — default 8.
+2. **`--num-indices`** — default 8. Bump to 16+ if the dataset is fast (~ms/call); the first call has cold-start overhead and a wider average smooths it out.
 3. **`--profile-scope`** — default `local` (only the dataset class + its defining module). Use `package` if the user's transforms / IO helpers live in sibling modules of the same top-level package.
 4. **`--num-workers`** for the DataLoader bench — default 4.
+5. **`--bench-batches`** — default 50. **Use the same value for `baseline` and every `measure` call**, otherwise `dataloader_speedup_x` is comparing different bench configurations.
 
 Then:
 
 1. Add `.getitem-profile/` to `.gitignore` if not already present.
 2. Create the side branch: `git checkout -b getitem-profile/<dataset-slug>-<YYYYMMDD-HHMM>` off the user's current `HEAD`.
-3. Run `python scripts/profile_getitem.py baseline --factory <factory> --num-indices <N> --profile-scope <scope> --num-workers <W> --out-dir .getitem-profile/`.
+3. Run `python scripts/profile_getitem.py baseline --factory <factory> --num-indices <N> --profile-scope <scope> --num-workers <W> --bench-batches <B> --out-dir .getitem-profile/`.
 4. Read `.getitem-profile/baseline.json`.
 5. Bail if either:
    - `equality_mode == "non_deterministic"` — surface the `first_diff_path` to the user, name the leaf that differs, offer two paths: (a) supply `--equality-fn pkg.mod:fn` that tolerates the non-determinism, (b) bail. Never silently fall back to tolerance.
@@ -45,7 +46,7 @@ State you maintain across iterations:
 
 Per iteration:
 
-1. **Pick the next-slowest line** from the most recent JSON's `line_stats` (sorted by `pct` descending) that is not in `failed_lines` and whose `file` lives inside the dataset module's directory or sibling modules in the same top-level package. If the slowest line is outside this scope (a `--profile-scope=package` artifact, e.g., a third-party helper), note it and skip to the next.
+1. **Pick the next-slowest line** from the most recent JSON's `line_stats` (sorted by `pct` descending) that is not in `failed_lines` and whose `file` lives inside the dataset module's directory or sibling modules in the same top-level package. If the slowest line is outside this scope (a `--profile-scope=package` artifact, e.g., a third-party helper), add it to `failed_lines` (so it's not re-picked next iteration) and skip to the next.
 2. **Termination checks:**
    - If the targeted line's `pct` < 5% → stop (diminishing returns).
    - If `consecutive_failures >= 3` → stop.
@@ -60,7 +61,7 @@ Per iteration:
    - remove a redundant `.copy()` or `.contiguous()`
    - pre-tokenize / pre-resize at dataset init time
 5. **Apply the edit** (single Edit tool call). Do NOT commit yet.
-6. **Run** `python scripts/profile_getitem.py measure --factory <factory> --baseline-dir .getitem-profile/ --profile-scope <scope> --num-workers <W>`. Read the new `measure-N.json`.
+6. **Run** `python scripts/profile_getitem.py measure --factory <factory> --baseline-dir .getitem-profile/ --profile-scope <scope> --num-workers <W> --bench-batches <B>`. Read the new `measure-N.json`. Pass the SAME `<B>` you used for `baseline`.
 7. **Decision** — use `delta_vs_prev_accepted.per_call_speedup_x`:
    - **Equality failed** → `git restore <changed_file>`. Add the line to `failed_lines`. `consecutive_failures += 1`.
    - **Equality passed but speedup < 1.05×** → same `git restore` path. Smaller wins are noise.
@@ -77,7 +78,7 @@ After each accepted edit, append to `.getitem-profile/session.md`:
 - commit: <short SHA>
 ```
 
-Append rejected attempts under a separate `## Rejected` section: target line + brief reason.
+Append rejected attempts under a separate `## Rejected` section, one bullet each: `- <file>:<line> — <reason>` (so resumption can parse them back into `failed_lines`).
 
 ## Hard rules
 
@@ -108,4 +109,4 @@ When the loop terminates (any condition), print:
 
 ## Resumption
 
-If a session is interrupted and the user re-invokes the skill: detect an existing `.getitem-profile/` dir + `getitem-profile/...` branch; read `session.md` to recover `failed_lines` and `accepted_commits`; resume the loop without re-baselining. The cached outputs in `.getitem-profile/baseline/` and `baseline.json` remain authoritative.
+If a session is interrupted and the user re-invokes the skill: detect an existing `.getitem-profile/` dir + `getitem-profile/...` branch; recover `accepted_commits` from `git log` on the side branch and `failed_lines` from the `## Rejected` bullets in `session.md`; resume the loop without re-baselining. The cached outputs in `.getitem-profile/baseline/` and `baseline.json` remain authoritative.

--- a/plugins/ml-research/skills/getitem-profiler/SKILL.md
+++ b/plugins/ml-research/skills/getitem-profiler/SKILL.md
@@ -1,6 +1,111 @@
 ---
 name: getitem-profiler
-description: Profile Dataset.__getitem__ with line_profiler and greedily optimize the slowest line on a side branch, gated by output equality and a per-call speedup threshold. Use when the user says "__getitem__ is slow", "profile my dataset", "speed up my dataloader", or supplies a factory function and asks for optimization.
+description: Profile Dataset.__getitem__ with line_profiler and greedily optimize the slowest line on a side branch, gated by output equality and a per-call speedup threshold. Use when the user says "__getitem__ is slow", "profile my dataset", "speed up my dataloader", "find the bottleneck in my dataset class", or supplies a factory function and asks for optimization.
 ---
 
-(Body filled in by Task 4.)
+## Identity
+
+Greedy line-level optimizer for `Dataset.__getitem__`. The harness at `scripts/profile_getitem.py` is the source of truth for measurement — never guess at timings, never decide acceptance from memory. After every edit, re-invoke the harness and read its JSON.
+
+You do not read the user's full dataset module up front. You read just enough surrounding code per edit to understand the line being targeted. The harness handles all instrumentation, seeding, equality checks, and benchmarking.
+
+## Setup (once per session)
+
+Confirm with the user:
+
+1. **Factory path** — `pkg.mod:make_dataset` returning a ready dataset instance. Document the one-liner template if the user doesn't have one yet:
+   ```python
+   def make_dataset():
+       from mypkg.dataset import MyDataset
+       return MyDataset(root="/path", split="train", transform=...)
+   ```
+2. **`--num-indices`** — default 8.
+3. **`--profile-scope`** — default `local` (only the dataset class + its defining module). Use `package` if the user's transforms / IO helpers live in sibling modules of the same top-level package.
+4. **`--num-workers`** for the DataLoader bench — default 4.
+
+Then:
+
+1. Add `.getitem-profile/` to `.gitignore` if not already present.
+2. Create the side branch: `git checkout -b getitem-profile/<dataset-slug>-<YYYYMMDD-HHMM>` off the user's current `HEAD`.
+3. Run `python scripts/profile_getitem.py baseline --factory <factory> --num-indices <N> --profile-scope <scope> --num-workers <W> --out-dir .getitem-profile/`.
+4. Read `.getitem-profile/baseline.json`.
+5. Bail if either:
+   - `equality_mode == "non_deterministic"` — surface the `first_diff_path` to the user, name the leaf that differs, offer two paths: (a) supply `--equality-fn pkg.mod:fn` that tolerates the non-determinism, (b) bail. Never silently fall back to tolerance.
+   - `reliable_line_stats == false` — tell the user the dataset is already fast (mean per-call < ~1 ms); wins here would be in the noise.
+6. Otherwise, show the user a brief table of the top-5 slowest lines + the baseline DataLoader throughput so they know the starting point.
+
+Surface the **caveat layer** (verbatim, see below) at session start.
+
+## The greedy loop
+
+State you maintain across iterations:
+- `failed_lines: set[(file, line)]` — lines we've already tried and failed on.
+- `consecutive_failures: int` — reset to 0 on accept.
+- `accepted_commits: list[str]` — for the final summary.
+
+Per iteration:
+
+1. **Pick the next-slowest line** from the most recent JSON's `line_stats` (sorted by `pct` descending) that is not in `failed_lines` and whose `file` lives inside the dataset module's directory or sibling modules in the same top-level package. If the slowest line is outside this scope (a `--profile-scope=package` artifact, e.g., a third-party helper), note it and skip to the next.
+2. **Termination checks:**
+   - If the targeted line's `pct` < 5% → stop (diminishing returns).
+   - If `consecutive_failures >= 3` → stop.
+   - If the user has interrupted → stop.
+3. **Read just enough**: the function the line is in, ~20 surrounding lines, and any helper it calls. Don't read the whole module.
+4. **Propose one concrete edit.** Common-win categories (vocabulary, not a checklist):
+   - vectorize a Python loop into numpy/torch ops
+   - replace PIL with `cv2` or `torchvision.io` for decode
+   - cache an expensive constant in `__init__`
+   - replace per-call file open with mmap or a pre-indexed handle
+   - construct tensors on the right dtype/device once
+   - remove a redundant `.copy()` or `.contiguous()`
+   - pre-tokenize / pre-resize at dataset init time
+5. **Apply the edit** (single Edit tool call). Do NOT commit yet.
+6. **Run** `python scripts/profile_getitem.py measure --factory <factory> --baseline-dir .getitem-profile/ --profile-scope <scope> --num-workers <W>`. Read the new `measure-N.json`.
+7. **Decision** — use `delta_vs_prev_accepted.per_call_speedup_x`:
+   - **Equality failed** → `git restore <changed_file>`. Add the line to `failed_lines`. `consecutive_failures += 1`.
+   - **Equality passed but speedup < 1.05×** → same `git restore` path. Smaller wins are noise.
+   - **Equality passed and speedup ≥ 1.05×** → `git add <file>` + `git commit -m "perf(<file>:<line>): <one-line summary>"`. Reset `consecutive_failures = 0`. Append an entry to `.getitem-profile/session.md`.
+8. Loop.
+
+After each accepted edit, append to `.getitem-profile/session.md`:
+
+```markdown
+## Edit <N> — <one-line summary>
+- target: <file>:<line> (was <pct>% of __getitem__)
+- per-call: <before> ms → <after> ms (<delta_vs_prev_accepted.per_call_speedup_x>x)
+- dataloader: <before> batches/s → <after> batches/s (<delta_vs_prev_accepted.dataloader_speedup_x>x)
+- commit: <short SHA>
+```
+
+Append rejected attempts under a separate `## Rejected` section: target line + brief reason.
+
+## Hard rules
+
+- **Edit-scope limit.** Edit only inside the dataset class / its defining module / sibling modules in the same top-level package, scoped by `--profile-scope`. Never broaden silently. If the slowest line is outside scope, skip it.
+- **No mutable cross-call state.** Caching `__getitem__` results across calls is forbidden. The per-index equality check would pass while DataLoader workers (which fork the dataset) silently diverge.
+- **No validation-set edits.** Don't touch validation code or any code path outside `__getitem__`'s call graph.
+- **one edit per commit.** No bundling — defeats per-line attribution. The harness's accept/reject decision is per-edit; mixing two changes in one commit makes attribution impossible.
+- **Side branch only.** Never touch `main` or the user's prior branch. The skill never deletes the side branch — the user merges or discards.
+
+## Caveat layer
+
+Surface this at session start AND in the final summary:
+
+> Per-call timings come from in-process measurement; under a real DataLoader, fixed costs (worker startup, IPC, fork-time imports) won't show up here. The DataLoader micro-benchmark gives a sanity check, but wins below ~50 µs per call may not translate. Wins should generally hold across distributed ranks since each rank's workers are independent.
+
+## Termination summary
+
+When the loop terminates (any condition), print:
+
+- starting per-call wall time (from `baseline.json`)
+- ending per-call wall time (from the most recent accepted measure)
+- total speedup (`delta_vs_baseline.per_call_speedup_x`)
+- DataLoader throughput before/after
+- list of accepted commits with one-line summaries
+- list of rejected target lines with brief reasons
+- the caveat layer (repeated)
+- the branch name; instruct the user to review and merge/discard
+
+## Resumption
+
+If a session is interrupted and the user re-invokes the skill: detect an existing `.getitem-profile/` dir + `getitem-profile/...` branch; read `session.md` to recover `failed_lines` and `accepted_commits`; resume the loop without re-baselining. The cached outputs in `.getitem-profile/baseline/` and `baseline.json` remain authoritative.

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -7,8 +7,21 @@ prompt that drives this script.
 from __future__ import annotations
 
 import argparse
+import importlib
+import json
+import pickle
+import random
 import sys
-from typing import Any
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+
+RELIABLE_LINE_STATS_THRESHOLD_S = 1e-3  # below this, line_profiler overhead dominates
 
 
 def deep_equal(a: Any, b: Any, _path: str = "outputs") -> tuple[bool, str | None, str | None]:
@@ -101,14 +114,219 @@ def deep_equal(a: Any, b: Any, _path: str = "outputs") -> tuple[bool, str | None
         return False, _path, f"comparison failed for {type(a).__name__}: {e}"
 
 
+def load_factory(spec: str) -> Callable:
+    """Resolve 'pkg.mod:attr' to a callable factory."""
+    if ":" not in spec:
+        raise ValueError(f"--factory must be 'pkg.mod:attr', got {spec!r}")
+    mod_path, attr = spec.split(":", 1)
+    mod = importlib.import_module(mod_path)
+    fn = getattr(mod, attr)
+    if not callable(fn):
+        raise TypeError(f"{spec} is not callable")
+    return fn
+
+
+def seed_all(seed: int) -> None:
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+
+
+def call_one(dataset, idx: int, seed_base: int):
+    """Seed RNGs and call dataset[idx]. Returns (output, wall_time_s) or raises."""
+    seed_all(seed_base + idx)
+    t0 = time.perf_counter()
+    out = dataset[idx]
+    dt = time.perf_counter() - t0
+    return out, dt
+
+
+def run_line_profiler(dataset, indices: list[int], seed_base: int, profile_scope: str):
+    """Returns the list of line_stats dicts (file, function, line, code, hits, time_s, pct)."""
+    from line_profiler import LineProfiler  # type: ignore
+    from line_profiler.scoping_policy import ScopingPolicy  # type: ignore
+
+    prof = LineProfiler()
+    cls = type(dataset)
+    mod = sys.modules[cls.__module__]
+    prof.add_class(cls, scoping_policy=ScopingPolicy.CHILDREN, wrap=True)
+    prof.add_module(mod, scoping_policy=ScopingPolicy.CHILDREN, wrap=True)
+    if profile_scope == "package":
+        top = cls.__module__.split(".")[0]
+        for name, m in list(sys.modules.items()):
+            if name == cls.__module__:
+                continue
+            if (name == top or name.startswith(top + ".")) and m is not None:
+                prof.add_module(m, scoping_policy=ScopingPolicy.CHILDREN, wrap=True)
+
+    prof.enable_by_count()
+    try:
+        for i in indices:
+            seed_all(seed_base + i)
+            _ = dataset[i]
+    finally:
+        prof.disable_by_count()
+
+    stats = prof.get_stats()
+    # Build per-line dicts. stats.timings: {(filename, lineno_start, name): [(lineno, hits, time_us)]}
+    # Convert microseconds to seconds; compute pct vs sum of all timed lines.
+    rows = []
+    for (filename, _start_lineno, fn_name), entries in stats.timings.items():
+        # Pull source lines for the `code` field.
+        try:
+            source = Path(filename).read_text().splitlines()
+        except OSError:
+            source = []
+        for lineno, hits, time_us in entries:
+            time_s = time_us * stats.unit  # stats.unit is the conversion to seconds
+            code = source[lineno - 1].strip() if 0 < lineno <= len(source) else ""
+            rows.append({
+                "file": filename,
+                "function": fn_name,
+                "line": lineno,
+                "code": code,
+                "hits": hits,
+                "time_s": time_s,
+            })
+    total = sum(r["time_s"] for r in rows) or 1.0
+    for r in rows:
+        r["pct"] = round(100.0 * r["time_s"] / total, 2)
+    rows.sort(key=lambda r: r["time_s"], reverse=True)
+    return rows
+
+
+def run_dataloader_bench(dataset, num_workers: int, batch_size: int, batches: int) -> dict:
+    """Run a short DataLoader iteration. Drops the first batch (worker warmup)."""
+    loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        shuffle=False,
+        drop_last=True,
+    )
+    timings: list[float] = []
+    it = iter(loader)
+    # Warmup batch
+    try:
+        next(it)
+    except StopIteration:
+        pass
+    for _ in range(batches):
+        t0 = time.perf_counter()
+        try:
+            next(it)
+        except StopIteration:
+            break
+        timings.append(time.perf_counter() - t0)
+    if not timings:
+        return {
+            "num_workers": num_workers,
+            "batch_size": batch_size,
+            "batches_measured": 0,
+            "batches_per_sec": 0.0,
+            "mean_batch_latency_s": 0.0,
+        }
+    mean_latency = sum(timings) / len(timings)
+    return {
+        "num_workers": num_workers,
+        "batch_size": batch_size,
+        "batches_measured": len(timings),
+        "batches_per_sec": 1.0 / mean_latency if mean_latency > 0 else 0.0,
+        "mean_batch_latency_s": mean_latency,
+    }
+
+
+def cmd_baseline(args) -> int:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "baseline").mkdir(exist_ok=True)
+
+    factory = load_factory(args.factory)
+    dataset = factory()
+
+    if args.indices:
+        indices = [int(x) for x in args.indices.split(",")]
+    else:
+        indices = list(range(args.num_indices))
+    seed_base = args.seed_base
+
+    # Determinism self-check: call each index twice, compare.
+    per_call_times: list[float] = []
+    cached_outputs: list = []
+    for i in indices:
+        out_a, dt = call_one(dataset, i, seed_base)
+        out_b, _ = call_one(dataset, i, seed_base)
+        ok, diff_path, summary = deep_equal(out_a, out_b)
+        if not ok:
+            payload = {
+                "factory": args.factory,
+                "indices": indices,
+                "seed_base": seed_base,
+                "equality_mode": "non_deterministic",
+                "first_diff_path": diff_path,
+                "summary": summary,
+            }
+            (out_dir / "baseline.json").write_text(json.dumps(payload, indent=2))
+            return 0
+        per_call_times.append(dt)
+        cached_outputs.append(out_a)
+
+    # Cache outputs.
+    for i, out in zip(indices, cached_outputs):
+        with open(out_dir / "baseline" / f"{i}.pkl", "wb") as f:
+            pickle.dump(out, f)
+
+    mean_per_call = sum(per_call_times) / len(per_call_times)
+    reliable = mean_per_call >= RELIABLE_LINE_STATS_THRESHOLD_S
+
+    # Line profiler.
+    line_stats = run_line_profiler(dataset, indices, seed_base, args.profile_scope)
+
+    # DataLoader bench. (Re-instantiate so workers don't share state from above.)
+    bench_dataset = factory()
+    bench = run_dataloader_bench(
+        bench_dataset, args.num_workers, args.batch_size, args.bench_batches
+    )
+
+    payload = {
+        "factory": args.factory,
+        "indices": indices,
+        "seed_base": seed_base,
+        "equality_mode": "strict",
+        "reliable_line_stats": reliable,
+        "per_call_wall_time_s": {
+            "mean": mean_per_call,
+            "indices": per_call_times,
+        },
+        "line_stats": line_stats,
+        "dataloader_bench": bench,
+    }
+    (out_dir / "baseline.json").write_text(json.dumps(payload, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="profile_getitem.py")
     sub = parser.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("baseline")
-    sub.add_parser("measure")
+
+    p_b = sub.add_parser("baseline")
+    p_b.add_argument("--factory", required=True, help="pkg.mod:attr factory function")
+    p_b.add_argument("--num-indices", type=int, default=8)
+    p_b.add_argument("--indices", type=str, default="", help="comma-separated, overrides --num-indices")
+    p_b.add_argument("--profile-scope", choices=["local", "package"], default="local")
+    p_b.add_argument("--num-workers", type=int, default=4)
+    p_b.add_argument("--batch-size", type=int, default=16)
+    p_b.add_argument("--bench-batches", type=int, default=50)
+    p_b.add_argument("--seed-base", type=int, default=0)
+    p_b.add_argument("--out-dir", type=str, default=".getitem-profile")
+    p_b.set_defaults(func=cmd_baseline)
+
+    p_m = sub.add_parser("measure")
+    # Filled in by Task 3.
+    p_m.set_defaults(func=lambda a: (print("not yet implemented", file=sys.stderr), 1)[1])
+
     args = parser.parse_args(argv)
-    print(f"stub: cmd={args.cmd}", file=sys.stderr)
-    return 0
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -188,9 +188,9 @@ def run_line_profiler(dataset, indices: list[int], seed_base: int, profile_scope
                 "hits": hits,
                 "time_s": time_s,
             })
-    total = sum(r["time_s"] for r in rows) or 1.0
+    total = sum(r["time_s"] for r in rows)
     for r in rows:
-        r["pct"] = round(100.0 * r["time_s"] / total, 2)
+        r["pct"] = round(100.0 * r["time_s"] / total, 2) if total > 0 else 0.0
     rows.sort(key=lambda r: r["time_s"], reverse=True)
     return rows
 
@@ -206,7 +206,6 @@ def run_dataloader_bench(dataset, num_workers: int, batch_size: int, batches: in
     )
     timings: list[float] = []
     it = iter(loader)
-    # Warmup batch
     try:
         next(it)
     except StopIteration:
@@ -271,7 +270,6 @@ def cmd_baseline(args) -> int:
         per_call_times.append(dt)
         cached_outputs.append(out_a)
 
-    # Cache outputs.
     for i, out in zip(indices, cached_outputs):
         with open(out_dir / "baseline" / f"{i}.pkl", "wb") as f:
             pickle.dump(out, f)
@@ -279,10 +277,10 @@ def cmd_baseline(args) -> int:
     mean_per_call = sum(per_call_times) / len(per_call_times)
     reliable = mean_per_call >= RELIABLE_LINE_STATS_THRESHOLD_S
 
-    # Line profiler.
     line_stats = run_line_profiler(dataset, indices, seed_base, args.profile_scope)
 
-    # DataLoader bench. (Re-instantiate so workers don't share state from above.)
+    # Fresh dataset for the bench: line_profiler may have wrapped methods on the
+    # one above; rebuilding via the factory gets a clean object for measurement.
     bench_dataset = factory()
     bench = run_dataloader_bench(
         bench_dataset, args.num_workers, args.batch_size, args.bench_batches

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -18,7 +18,6 @@ def deep_equal(a: Any, b: Any, _path: str = "outputs") -> tuple[bool, str | None
     Handles dicts, lists, tuples, torch tensors, numpy arrays, PIL Images, and
     primitive types. Unknown leaf types fall back to ==.
     """
-    # Handle types in order: containers first, then leaf types.
     if isinstance(a, dict) or isinstance(b, dict):
         if not (isinstance(a, dict) and isinstance(b, dict)):
             return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
@@ -95,7 +94,9 @@ def deep_equal(a: Any, b: Any, _path: str = "outputs") -> tuple[bool, str | None
     try:
         if a == b:
             return True, None, None
-        return False, _path, f"{type(a).__name__} != {type(b).__name__}: {a!r} vs {b!r}"
+        if type(a) is not type(b):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        return False, _path, f"values differ: {a!r} vs {b!r}"
     except Exception as e:  # noqa: BLE001
         return False, _path, f"comparison failed for {type(a).__name__}: {e}"
 

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -312,9 +312,12 @@ def _next_measure_path(out_dir: Path) -> Path:
 
 def _latest_accepted_measure(out_dir: Path) -> dict | None:
     """Return the most recent measure-N.json with equality.passed == true, or None."""
-    files = sorted(out_dir.glob("measure-*.json"),
-                   key=lambda p: int(p.stem.split("-")[1]),
-                   reverse=True)
+    numbered: list[tuple[int, Path]] = []
+    for p in out_dir.glob("measure-*.json"):
+        suffix = p.stem.removeprefix("measure-")
+        if suffix.isdigit():
+            numbered.append((int(suffix), p))
+    files = [p for _, p in sorted(numbered, key=lambda t: t[0], reverse=True)]
     for f in files:
         try:
             data = json.loads(f.read_text())

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -303,6 +303,129 @@ def cmd_baseline(args) -> int:
     return 0
 
 
+def _next_measure_path(out_dir: Path) -> Path:
+    n = 1
+    while (out_dir / f"measure-{n}.json").exists():
+        n += 1
+    return out_dir / f"measure-{n}.json"
+
+
+def _latest_accepted_measure(out_dir: Path) -> dict | None:
+    """Return the most recent measure-N.json with equality.passed == true, or None."""
+    files = sorted(out_dir.glob("measure-*.json"),
+                   key=lambda p: int(p.stem.split("-")[1]),
+                   reverse=True)
+    for f in files:
+        try:
+            data = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("equality", {}).get("passed") is True:
+            return data
+    return None
+
+
+def _compute_delta(curr_mean: float, curr_bench_bps: float,
+                   ref_mean: float, ref_bench_bps: float) -> dict:
+    return {
+        "per_call_speedup_x": (ref_mean / curr_mean) if curr_mean > 0 else 0.0,
+        "dataloader_speedup_x": (curr_bench_bps / ref_bench_bps) if ref_bench_bps > 0 else 0.0,
+    }
+
+
+def cmd_measure(args) -> int:
+    baseline_dir = Path(args.baseline_dir)
+    baseline_path = baseline_dir / "baseline.json"
+    if not baseline_path.exists():
+        print(f"baseline.json not found at {baseline_path}", file=sys.stderr)
+        return 2
+    baseline = json.loads(baseline_path.read_text())
+    if baseline.get("equality_mode") == "non_deterministic":
+        print("baseline is non-deterministic; cannot measure", file=sys.stderr)
+        return 2
+
+    factory = load_factory(args.factory)
+    dataset = factory()
+
+    indices = baseline["indices"]
+    seed_base = baseline["seed_base"]
+
+    measure_path = _next_measure_path(baseline_dir)
+
+    # Equality check (fail-fast: bail at first mismatch or exception).
+    per_call_times: list[float] = []
+    for i in indices:
+        try:
+            seed_all(seed_base + i)
+            t0 = time.perf_counter()
+            out = dataset[i]
+            dt = time.perf_counter() - t0
+        except Exception as e:  # noqa: BLE001
+            payload = {
+                "equality": {
+                    "passed": False,
+                    "first_diff_path": f"outputs[{i}]",
+                    "summary": f"raised {type(e).__name__}: {e}",
+                },
+            }
+            measure_path.write_text(json.dumps(payload, indent=2))
+            return 0
+        with open(baseline_dir / "baseline" / f"{i}.pkl", "rb") as f:
+            cached = pickle.load(f)
+        ok, diff_path, summary = deep_equal(out, cached, _path=f"outputs[{i}]")
+        if not ok:
+            payload = {
+                "equality": {"passed": False, "first_diff_path": diff_path, "summary": summary},
+            }
+            measure_path.write_text(json.dumps(payload, indent=2))
+            return 0
+        per_call_times.append(dt)
+
+    # Equality passed → re-profile + bench.
+    line_stats = run_line_profiler(dataset, indices, seed_base, args.profile_scope)
+
+    bench_dataset = factory()
+    try:
+        bench = run_dataloader_bench(
+            bench_dataset, args.num_workers, args.batch_size, args.bench_batches
+        )
+    except Exception as e:  # noqa: BLE001
+        payload = {
+            "equality": {
+                "passed": False,
+                "first_diff_path": "<dataloader>",
+                "summary": f"dataloader bench raised {type(e).__name__}: {e}",
+            },
+        }
+        measure_path.write_text(json.dumps(payload, indent=2))
+        return 0
+
+    mean_per_call = sum(per_call_times) / len(per_call_times)
+    baseline_mean = baseline["per_call_wall_time_s"]["mean"]
+    baseline_bps = baseline["dataloader_bench"]["batches_per_sec"]
+
+    prev = _latest_accepted_measure(baseline_dir)
+    if prev:
+        prev_mean = prev["per_call_wall_time_s"]["mean"]
+        prev_bps = prev["dataloader_bench"]["batches_per_sec"]
+    else:
+        prev_mean = baseline_mean
+        prev_bps = baseline_bps
+
+    payload = {
+        "equality": {"passed": True},
+        "per_call_wall_time_s": {"mean": mean_per_call, "indices": per_call_times},
+        "delta_vs_baseline": _compute_delta(mean_per_call, bench["batches_per_sec"],
+                                            baseline_mean, baseline_bps),
+        "delta_vs_prev_accepted": _compute_delta(mean_per_call, bench["batches_per_sec"],
+                                                 prev_mean, prev_bps),
+        "line_stats": line_stats,
+        "dataloader_bench": bench,
+    }
+    measure_path.write_text(json.dumps(payload, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="profile_getitem.py")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -320,8 +443,13 @@ def main(argv: list[str] | None = None) -> int:
     p_b.set_defaults(func=cmd_baseline)
 
     p_m = sub.add_parser("measure")
-    # Filled in by Task 3.
-    p_m.set_defaults(func=lambda a: (print("not yet implemented", file=sys.stderr), 1)[1])
+    p_m.add_argument("--factory", required=True)
+    p_m.add_argument("--baseline-dir", required=True)
+    p_m.add_argument("--profile-scope", choices=["local", "package"], default="local")
+    p_m.add_argument("--num-workers", type=int, default=4)
+    p_m.add_argument("--batch-size", type=int, default=16)
+    p_m.add_argument("--bench-batches", type=int, default=50)
+    p_m.set_defaults(func=cmd_measure)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""getitem-profiler measurement harness.
+
+See plugins/ml-research/skills/getitem-profiler/SKILL.md for the orchestration
+prompt that drives this script.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="profile_getitem.py")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("baseline")
+    sub.add_parser("measure")
+    args = parser.parse_args(argv)
+    print(f"stub: cmd={args.cmd}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
+++ b/plugins/ml-research/skills/getitem-profiler/scripts/profile_getitem.py
@@ -8,6 +8,96 @@ from __future__ import annotations
 
 import argparse
 import sys
+from typing import Any
+
+
+def deep_equal(a: Any, b: Any, _path: str = "outputs") -> tuple[bool, str | None, str | None]:
+    """Recursively compare two outputs.
+
+    Returns (True, None, None) on equal; (False, first_diff_path, summary) on mismatch.
+    Handles dicts, lists, tuples, torch tensors, numpy arrays, PIL Images, and
+    primitive types. Unknown leaf types fall back to ==.
+    """
+    # Handle types in order: containers first, then leaf types.
+    if isinstance(a, dict) or isinstance(b, dict):
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if set(a.keys()) != set(b.keys()):
+            return False, _path, f"key sets differ: {sorted(a.keys())} vs {sorted(b.keys())}"
+        for k in a:
+            ok, p, s = deep_equal(a[k], b[k], f"{_path}.{k}")
+            if not ok:
+                return False, p, s
+        return True, None, None
+
+    if isinstance(a, (list, tuple)) or isinstance(b, (list, tuple)):
+        if type(a) is not type(b):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if len(a) != len(b):
+            return False, _path, f"length mismatch: {len(a)} vs {len(b)}"
+        for i, (ai, bi) in enumerate(zip(a, b)):
+            ok, p, s = deep_equal(ai, bi, f"{_path}[{i}]")
+            if not ok:
+                return False, p, s
+        return True, None, None
+
+    # Lazy imports so the equality module doesn't hard-require torch/numpy/PIL
+    # to be importable at module load (the harness imports them at top level
+    # anyway, but keeping deep_equal robust in isolation makes it easier to
+    # smoke-test).
+    try:
+        import torch  # type: ignore
+    except ImportError:
+        torch = None  # type: ignore
+    try:
+        import numpy as np  # type: ignore
+    except ImportError:
+        np = None  # type: ignore
+    try:
+        from PIL import Image  # type: ignore
+    except ImportError:
+        Image = None  # type: ignore
+
+    if torch is not None and (isinstance(a, torch.Tensor) or isinstance(b, torch.Tensor)):
+        if not (isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if a.shape != b.shape:
+            return False, _path, f"tensor shape {tuple(a.shape)} vs {tuple(b.shape)}"
+        if a.dtype != b.dtype:
+            return False, _path, f"tensor dtype {a.dtype} vs {b.dtype}"
+        if not torch.equal(a, b):
+            return False, _path, "tensor values differ"
+        return True, None, None
+
+    if np is not None and (isinstance(a, np.ndarray) or isinstance(b, np.ndarray)):
+        if not (isinstance(a, np.ndarray) and isinstance(b, np.ndarray)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if a.shape != b.shape:
+            return False, _path, f"array shape {a.shape} vs {b.shape}"
+        if a.dtype != b.dtype:
+            return False, _path, f"array dtype {a.dtype} vs {b.dtype}"
+        if not np.array_equal(a, b):
+            return False, _path, "array values differ"
+        return True, None, None
+
+    if Image is not None and (isinstance(a, Image.Image) or isinstance(b, Image.Image)):
+        if not (isinstance(a, Image.Image) and isinstance(b, Image.Image)):
+            return False, _path, f"type mismatch: {type(a).__name__} vs {type(b).__name__}"
+        if a.size != b.size:
+            return False, _path, f"PIL size {a.size} vs {b.size}"
+        if a.mode != b.mode:
+            return False, _path, f"PIL mode {a.mode} vs {b.mode}"
+        if a.tobytes() != b.tobytes():
+            return False, _path, "PIL pixel bytes differ"
+        return True, None, None
+
+    # Fallback: ==, capturing exceptions.
+    try:
+        if a == b:
+            return True, None, None
+        return False, _path, f"{type(a).__name__} != {type(b).__name__}: {a!r} vs {b!r}"
+    except Exception as e:  # noqa: BLE001
+        return False, _path, f"comparison failed for {type(a).__name__}: {e}"
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/plugins/ml-research/skills/getitem-profiler/tests/fixtures/README.md
+++ b/plugins/ml-research/skills/getitem-profiler/tests/fixtures/README.md
@@ -1,0 +1,6 @@
+# Test fixtures
+
+Synthetic datasets used to exercise `scripts/profile_getitem.py` during development. There is no pytest suite — fixtures are imported via the harness's `--factory` flag.
+
+- `tiny_image_dataset.py:make_dataset` — deterministic under seeded RNGs, intentionally slow per-pixel loop in `__getitem__` so line_profiler has a clear hotspot to surface.
+- `nondeterministic_dataset.py:make_dataset` — uses `os.urandom`, deliberately bypassing standard RNGs. The harness should detect this and emit `equality_mode: non_deterministic` in `baseline.json`.

--- a/plugins/ml-research/skills/getitem-profiler/tests/fixtures/nondeterministic_dataset.py
+++ b/plugins/ml-research/skills/getitem-profiler/tests/fixtures/nondeterministic_dataset.py
@@ -1,0 +1,25 @@
+"""Synthetic dataset that bypasses seed-based determinism.
+
+Used to verify the harness's `equality_mode: non_deterministic` detection.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+class NondeterministicDataset:
+    def __len__(self) -> int:
+        return 32
+
+    def __getitem__(self, idx: int) -> dict:
+        # os.urandom isn't affected by torch.manual_seed / np.random.seed /
+        # random.seed — the harness should detect this and refuse to start
+        # the greedy loop.
+        n = int.from_bytes(os.urandom(4), "little")
+        return {"value": torch.tensor(float(n))}
+
+
+def make_dataset() -> NondeterministicDataset:
+    return NondeterministicDataset()

--- a/plugins/ml-research/skills/getitem-profiler/tests/fixtures/tiny_image_dataset.py
+++ b/plugins/ml-research/skills/getitem-profiler/tests/fixtures/tiny_image_dataset.py
@@ -1,0 +1,38 @@
+"""Synthetic dataset with a clear line_profiler hotspot.
+
+Used to exercise the getitem-profiler harness during development. The per-pixel
+Python loop in __getitem__ is the intentional bottleneck.
+"""
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+
+class TinyImageDataset:
+    def __init__(self, n: int = 32, side: int = 48) -> None:
+        self.n = n
+        self.side = side
+        # Per-index seeds so output depends only on idx (and the global RNG state
+        # at call time, which the harness controls via seed_all).
+        self._seeds = np.arange(n, dtype=np.int64)
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, idx: int) -> dict:
+        rng = np.random.default_rng(int(self._seeds[idx]))
+        arr = rng.uniform(0, 1, (self.side, self.side, 3)).astype(np.float32)
+        # Intentional hotspot: per-pixel Python loop — line_profiler will rank
+        # this line as the slowest. Vectorizing it (`out = arr * 2.0 - 1.0`)
+        # is the obvious optimization the harness would propose.
+        out = np.empty_like(arr)
+        for i in range(self.side):
+            for j in range(self.side):
+                out[i, j] = arr[i, j] * 2.0 - 1.0
+        img = torch.from_numpy(out).permute(2, 0, 1).contiguous()
+        return {"image": img, "label": int(idx % 10)}
+
+
+def make_dataset() -> TinyImageDataset:
+    return TinyImageDataset()

--- a/plugins/ml-research/skills/model-training/SKILL.md
+++ b/plugins/ml-research/skills/model-training/SKILL.md
@@ -114,9 +114,9 @@ Check for:
 - W&B run (if enabled) shows state transitions `running → preempting → running`.
 
 Re-run this test whenever modifying:
-- `ExceptionCallback.on_save_checkpoint` / `on_load_checkpoint` / `on_train_start`
-- `PreemptionCallback` signal handlers
-- `CellxGeneSampler` state-dict semantics
+- The project's exception-handling trainer callback (`on_save_checkpoint` / `on_load_checkpoint` / `on_train_start`)
+- The project's preemption-handling `SLURMEnvironment` subclass (signal handlers)
+- Any stateful sampler in the data module — anything with non-trivial `state_dict` / `load_state_dict` semantics that must survive a mid-validation preemption
 
 ## Full training runs
 

--- a/plugins/ml-research/skills/slurm/SKILL.md
+++ b/plugins/ml-research/skills/slurm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slurm
-description: Interact with an HPC cluster managed by SLURM — including NCSA Delta, University of Utah CHPC (notchpeak, kingspeak, lonepeak, granite, redwood), and any generic SLURM cluster. Use when submitting, monitoring, or debugging SLURM jobs; writing sbatch scripts; choosing partitions/QoS/accounts; tuning batch size; running interactive sessions (salloc, srun --pty); or diagnosing job failures (OOM, timeout, node errors). Also use when the user mentions sbatch, squeue, sacct, salloc, scancel, sprio, Delta, NCSA, bdhi, CHPC, notchpeak, job queues, GPU allocation, or cluster resource optimization.
+description: Interact with an HPC cluster managed by SLURM — including NCSA Delta, University of Utah CHPC (notchpeak, kingspeak, lonepeak, granite, redwood), and any generic SLURM cluster. Use when submitting, monitoring, or debugging SLURM jobs; writing sbatch scripts; choosing partitions/QoS/accounts; tuning batch size; running interactive sessions (salloc, srun --pty); or diagnosing job failures (OOM, timeout, node errors). Also use when the user mentions sbatch, squeue, sacct, salloc, scancel, sprio, Delta, NCSA, CHPC, notchpeak, job queues, GPU allocation, or cluster resource optimization.
 ---
 
 You are on an HPC cluster managed by SLURM. Read the [SLURM quickstart guide](https://slurm.schedmd.com/quickstart.html). You are likely on a login node, but if `nvidia-smi` shows available GPUs, you are probably on a GPU-enabled compute node.

--- a/plugins/ml-research/skills/slurm/clusters/delta.md
+++ b/plugins/ml-research/skills/slurm/clusters/delta.md
@@ -2,7 +2,7 @@
 
 Site-specific reference for the NCSA Delta cluster. Read alongside the generic SLURM guidance in this skill's `SKILL.md`.
 
-Account: `bdhi-delta-gpu`
+Delta allocations follow the pattern `<project-code>-delta-gpu` (for GPU access) and `<project-code>-delta-cpu` (for CPU-only access). Check the user's allocations with `accounts` or `mychpc usage`; ask them which account to charge if unclear.
 
 You have access to the `gnodes` and `jobinfo` executables provided by [slurm-utils](https://github.com/birc-aeh/slurm-utils/tree/master).
 
@@ -74,7 +74,7 @@ squeue -u "$USER" -o "%.10i %.12P %.8T %.10r %.10Q %.20S"      # job state, reas
 sprio -j <jobid> -l                                             # factor breakdown
 ```
 
-A `FairShare` score below ~0.2 means you're over-using and jobs will queue behind other users in `bdhi-delta-gpu`. Because decay half-life is 1 day, this self-corrects after roughly a day of lighter activity — it isn't a long-term penalty.
+A `FairShare` score below ~0.2 means you're over-using and jobs will queue behind other users in your account. Because decay half-life is 1 day, this self-corrects after roughly a day of lighter activity — it isn't a long-term penalty.
 
 Priority levers ranked by leverage, best to worst:
 
@@ -95,8 +95,8 @@ Age and QOS are not useful levers here.
 | WORK (NVME) | `/work/nvme/<code>` | By request | No | Many small-file I/O workloads. |
 | /tmp | Node-local SSD | 1.5 TB (GPU nodes) | After each job | Fast temporary storage. Not shared across nodes. |
 
-Our data directory: `/work/hdd/bdhi/$USER/data/`
-Job scratch pattern: `/work/hdd/bdhi/$USER/$SLURM_JOB_ID/` (set as `$TMPDIR` in sbatch scripts)
+Conventional data directory: `/work/hdd/<project-code>/$USER/data/`
+Conventional job scratch pattern: `/work/hdd/<project-code>/$USER/$SLURM_JOB_ID/` (set as `$TMPDIR` in sbatch scripts)
 
 ## Multi-node networking
 


### PR DESCRIPTION
Closes #4.

## Summary

Adds the `getitem-profiler` skill to the `ml-research` plugin: a thin orchestration prompt over a single-file Python harness that profiles `Dataset.__getitem__` with `line_profiler` and greedily optimizes the slowest line on a side branch, gated by output equality and a per-call speedup threshold.

- **`SKILL.md`** — agent-facing orchestration prompt: setup → greedy loop → hard rules → caveat layer → termination → resumption.
- **`scripts/profile_getitem.py`** — `baseline` and `measure` subcommands. `baseline` seeds RNGs, runs a determinism self-check, line-profiles via `LineProfiler.add_class` + `add_module` with `ScopingPolicy.CHILDREN`, runs a DataLoader micro-bench, and caches outputs as pkls. `measure` re-runs against the cached outputs, surfaces failures (equality mismatch, raised `__getitem__`, dataloader bench failure) through `equality.passed=false`, and computes both `delta_vs_baseline` and `delta_vs_prev_accepted` (the latter is the acceptance signal — 1.05× threshold).
- **`tests/fixtures/`** — synthetic deterministic and non-deterministic datasets used by the smoke test.
- **`docs/superpowers/specs/2026-04-26-getitem-profiler-design.md`** + **`docs/superpowers/plans/2026-04-26-getitem-profiler.md`** — design spec and 6-task implementation plan, both reviewed before execution.

## Design choices worth highlighting

- **Strict equality only.** Seed `torch`/`numpy`/`random` then compare via a recursive walker that handles dicts, lists, tuples, tensors, ndarrays, PIL Images, and primitives (dtype-strict). Bail on non-determinism — no auto-fallback to tolerance.
- **Acceptance against `delta_vs_prev_accepted`, not `delta_vs_baseline`.** After a few accepted edits, the cumulative bar trivializes; marginal speedup is the right signal.
- **Side-branch model** with edit → measure → commit-only-on-accept (no clutter from auto-revert commits).
- **`ScopingPolicy.CHILDREN`** on `add_class` + `add_module` is the `line_profiler` 5.x API matching the spec's intent; `LOCAL` does not exist in current versions.

## Test plan

Smoke test passed on the synthetic fixture: baseline 6.37 ms/call → vectorized edit accepted at 7.09× per-call speedup, fixture restored cleanly.

- [ ] `cd plugins/ml-research/skills/getitem-profiler && PYTHONPATH=tests/fixtures python scripts/profile_getitem.py baseline --factory tiny_image_dataset:make_dataset --num-indices 4 --num-workers 2 --bench-batches 10 --out-dir /tmp/sm` — exits 0, writes `baseline.json` with `equality_mode=strict`, top hotspot at the per-pixel loop body
- [ ] Vectorize the loop in `tests/fixtures/tiny_image_dataset.py`, run `measure` against the same baseline-dir — `equality.passed=true`, `delta_vs_prev_accepted.per_call_speedup_x ≥ 1.5`
- [ ] Run baseline against `nondeterministic_dataset:make_dataset` — `equality_mode=non_deterministic`, `first_diff_path` set, exit 0
- [ ] Inject a `RuntimeError` at the top of `__getitem__`, run `measure` — `equality.passed=false`, `summary` starts with `"raised "`

🤖 Generated with [Claude Code](https://claude.com/claude-code)