### PR TITLE
slurm: document TRES billing rates and right-sizing requests

### DIFF
--- a/plugins/ml-research/skills/slurm/SKILL.md
+++ b/plugins/ml-research/skills/slurm/SKILL.md
@@ -22,6 +22,8 @@ scontrol show config | grep ClusterName
 
 If the cluster isn't in the table, proceed with the generic guidance below and explicitly note that site-specific details (partitions, charge rates, filesystem paths, account/QoS triples) are unknown — ask the user for a link to the cluster's user guide or have them paste `sinfo` output.
 
+If the cluster is part of NSF ACCESS (Delta, Anvil, Bridges-2, Expanse, Stampede3, FASTER, Jetstream2, etc.), also read `clusters/access.md` for the portal-allocation-to-billing-unit mapping that supplements the cluster's own reference file. Don't assume a generic SLURM cluster is ACCESS-governed.
+
 ## Partition selection
 
 Before submitting, survey the cluster state to pick the best partition and resource request. The goal is to jointly minimize expected time-to-start, time-to-completion, and total charge.

--- a/plugins/ml-research/skills/slurm/SKILL.md
+++ b/plugins/ml-research/skills/slurm/SKILL.md
@@ -42,7 +42,63 @@ Key trade-offs:
 - **Preemptible partitions** typically have half the charge factor of their non-preemptible counterparts and shorter queue wait, but jobs can be preempted. Use for fault-tolerant workloads with checkpointing enabled.
 - **Interactive partitions** have shorter max durations (often 1 hr) and higher charge factors, but may have shorter wait times. Use only for debugging and quick iteration.
 - **GPU generation**: all else equal, prefer newer GPUs (Blackwell > Hopper > Ampere > Turing > Volta > Pascal) and more GPUs per node to reduce communication overhead. But if the cluster is busy, requesting fewer GPUs on an available partition may start sooner.
-- **Charge factors**: compare the effective cost by multiplying SUs by the partition's charge factor. A preemptible run at 0.5x that takes 1.2x as long (due to one preemption) is still cheaper.
+- **Billing rates**: the partition-level "charge factor" cited in cluster docs is shorthand for `TRESBillingWeights` (see next section). Effective cost depends on what the job actually requests, not just on which partition it lands in.
+
+## TRES billing rates
+
+A job's billing rate (the rate at which it consumes the project's allocation, expressed in billing-units per minute) is computed from the partition's `TRESBillingWeights` and the resources the job requests. Charge factors quoted in cluster documentation assume the job hits the "intended" shape for that partition — when it doesn't, the actual rate diverges, sometimes dramatically.
+
+```bash
+# The per-resource billing weights for a partition.
+scontrol show partition <p> | grep -E 'PartitionName|TRESBillingWeights'
+
+# How weights are combined.
+scontrol show config | grep PriorityFlags
+
+# What the scheduler actually computed for a specific job.
+scontrol show job <jobid> | grep -E 'ReqTRES|AllocTRES'   # the billing= field is the rate per minute
+```
+
+How weights combine depends on `PriorityFlags`:
+
+- `MAX_TRES` set: billing rate = max(weighted CPU, weighted Mem, weighted GPU). The job pays for whichever single TRES dominates; non-dominant requests are effectively free.
+- Default (no `MAX_TRES`): billing rate = sum of all weighted contributions. Every requested unit costs.
+
+Always check which mode applies before reasoning about cost.
+
+### Reading TRESBillingWeights
+
+A weight like `TRESBillingWeights=CPU=250, Mem=12G, GRES/gpu=3000` specifies billing-units per minute per resource:
+
+- `CPU=250` — 250 billing-units per CPU per minute.
+- `GRES/gpu=3000` — 3000 billing-units per GPU per minute.
+- `Mem=12G` — 1 billing-unit per **12 GB** of memory per minute. The size suffix on memory weights sets the *divisor*, not the multiplier; without a suffix, the value is per-MB. Read the suffix carefully.
+
+### Worked example (MAX_TRES)
+
+Partition with `TRESBillingWeights=CPU=250, Mem=12G, GRES/gpu=3000`, job requesting `cpu=33, mem=240G, gres/gpu=1`:
+
+| Resource | Computation | Billing/min |
+|---|---|---:|
+| CPU | 33 × 250 | **8250 ← dominant** |
+| GPU | 1 × 3000 | 3000 |
+| Mem | 240 / 12 | 20 |
+
+Billing rate = 8250/min — driven entirely by CPU. The GPU is "free" because it doesn't dominate. Same shape under SUM mode would bill at 8250 + 3000 + 20 = 11,270/min. Confirm by reading `billing=` in `scontrol show job`.
+
+### Right-sizing the request
+
+Under MAX_TRES, the leverage point is the dominant TRES — trim *that one* until another TRES takes over; cuts to non-dominant resources don't change billing. Under SUM, trim whichever requests are most over-provisioned.
+
+For a single-GPU job to make GPU the dominant TRES (and so cap the per-hour rate at the partition's GPU weight):
+- `cpus-per-task ≤ GRES/gpu_weight ÷ CPU_weight`
+- `mem ≤ GRES/gpu_weight × Mem_suffix_GB` (e.g. `Mem=12G` → up to `3000 × 12 = 36000 GB`)
+
+Above those thresholds you're paying for CPU or memory, not the GPU. Whether shrinking CPUs hurts dataloader throughput is a separate empirical question — verify with a short profiling run before committing to a smaller request.
+
+### Why this matters for QOSGrpBillingMinutes
+
+`AssocGrpBillingMinutes` / `QOSGrpBillingMinutes` quotas are denominated in the same billing-units. When `squeue` shows `Reason=QOSGrpBillingMinutes`, the scheduler has projected `billing_rate × TimeLimit` against the remaining quota and refused to start the job. Lowering the *dominant* request (under MAX_TRES) or shortening `--time` may unblock it; cutting non-dominant requests will not.
 
 ## Understanding job priority
 

--- a/plugins/ml-research/skills/slurm/clusters/access.md
+++ b/plugins/ml-research/skills/slurm/clusters/access.md
@@ -1,0 +1,49 @@
+# ACCESS-governed clusters
+
+Cross-cluster reference for clusters that draw allocations from the [NSF ACCESS](https://access-ci.org) program. Read alongside the generic SLURM guidance in this skill's `SKILL.md` and the cluster-specific reference for the cluster you're actually on.
+
+ACCESS-governed clusters covered by this skill:
+
+| Cluster | Reference file |
+|---|---|
+| NCSA Delta | `clusters/delta.md` |
+
+Other ACCESS resources (Anvil, Bridges-2, Expanse, Stampede3, FASTER, Jetstream2, etc.) follow the same allocation model but their per-resource conversion factors aren't documented here — derive them from the cluster's `TRESBillingWeights` using the framework below.
+
+## How ACCESS allocations map to SLURM billing
+
+ACCESS issues allocations in **ACCESS Credits**, a unified currency. The ACCESS portal displays per-resource balances in resource-native units (e.g. "GPU Hours" on a GPU resource, "Core Hours" on a CPU resource). Internally each cluster enforces the allocation via SLURM's `GrpTRESMins=billing=...` quota, denominated in the cluster's *local billing-units* — not ACCESS-portal units. Two conversions matter:
+
+1. **Portal unit → cluster billing-units.** Set by the cluster operator at allocation time. Inferable from `sacctmgr show qos <qos>`'s `GrpTRESMins=billing=N` divided by your portal-reported allocation in resource-native units.
+2. **Cluster billing-units → wallclock cost for a specific job.** Set by `TRESBillingWeights` and `PriorityFlags` on the partition (see SKILL.md "TRES billing rates"). This is what determines whether you're billed by GPU, CPU, or memory for your particular request.
+
+Both are needed to convert "I have N GPU Hours left in the portal" into "how long can I run this specific shape on this partition." Neither alone is sufficient.
+
+```bash
+# Local billing-units cap (cluster-side enforcement).
+sacctmgr show qos <qos> format=Name,GrpTRESMins
+# Per-resource portal balance: check the ACCESS portal at https://allocations.access-ci.org/
+# Project's cluster-side usage:
+sshare -A <account>
+```
+
+## When `Reason=QOSGrpBillingMinutes` fires
+
+The scheduler computes `billing_rate × TimeLimit` for the pending job and refuses to start it if `(used + projected) > GrpTRESMins`. This can fire well before the project hits zero on the ACCESS portal — a long `--time` on a large request projects a large cost.
+
+Levers, in order of leverage:
+1. Shorten `--time` on the pending job — projected cost is linear in walltime.
+2. Reduce the dominant TRES on the request (see SKILL.md). Reducing non-dominant TRES doesn't help under MAX_TRES.
+3. Wait for other project jobs to finish (frees up `used`).
+4. Request an allocation supplement via the ACCESS portal — multi-day turnaround, not a fix for an immediate deadline.
+
+## Caveats
+
+- The ACCESS portal balance is not always real-time; cluster-side enforcement uses the SLURM cap, which may be ahead or behind the portal by hours.
+- Some clusters charge differently across partitions (e.g. interactive partitions are 2× standard). The portal usually reports a single per-resource balance, leaving the per-partition multiplier implicit.
+- "GPU Hours" in the portal is a normalized unit, typically calibrated to one specific GPU type on the cluster (e.g. A100 on Delta). Newer/older GPUs charge at a multiple/fraction of that rate. The cluster-specific reference file lists the conversions.
+
+## ACCESS documentation
+
+- [ACCESS allocations](https://allocations.access-ci.org/)
+- [ACCESS user portal](https://access-ci.org/)

--- a/plugins/ml-research/skills/slurm/clusters/chpc.md
+++ b/plugins/ml-research/skills/slurm/clusters/chpc.md
@@ -37,6 +37,29 @@ Run `sacctmgr -p -n show assoc user=$USER format=cluster,account,partition` to s
 
 Preemptable partitions (`*-guest`, `*-freecycle`) can be killed at any time — only use for restartable/checkpointed work and set `--requeue` if appropriate.
 
+## TRES billing rates on CHPC
+
+CHPC bills against PI allocations (denominated in node-hours / SUs depending on cluster) for the standard general partitions (`<PI>`, `notchpeak`, `notchpeak-gpu`, equivalents on other clusters). Several partitions are explicitly free of allocation charge:
+
+- `notchpeak-shared-short` (and equivalents) — free, capped at 8 hr.
+- `*-freecycle` — uses idle general cycles, free, preemptable.
+- `*-guest` (`owner-guest`, `notchpeak-gpu-guest`) — preempts owner nodes, free.
+- `lonepeak` — no allocation required at all.
+
+For partitions that *do* bill, inspect the per-resource weights directly — values vary by cluster and change over time, so don't reason from cached numbers:
+
+```bash
+scontrol show partition <p> | grep -E 'PartitionName|TRESBillingWeights'
+scontrol show config | grep PriorityFlags     # MAX_TRES vs SUM
+scontrol show job <jobid> | grep -E 'ReqTRES|AllocTRES'  # billing= field is units/min
+```
+
+See SKILL.md's "TRES billing rates" section for how to compute the dominant TRES and right-size requests. Whole-node (non-shared) general partitions may bill on the whole node regardless of what the job requests — confirm by submitting a tiny test and reading the resulting `billing=` field before drawing conclusions about cost levers.
+
+For owner partitions (`<PI>-np`), the PI controls scheduling but jobs typically don't decrement a CHPC allocation. Treat them as free at the allocation level (subject to PI policy).
+
+When `Reason=AssocGrpBillingMinutes` or `QOSGrpBillingMinutes` shows up on a pending job, the PI's allocation is exhausted or projected-cost-plus-used would exceed it. Contact help@chpc.utah.edu for the current balance, or check `mychpc usage`.
+
 ## Writing an sbatch script
 
 Minimal template:

--- a/plugins/ml-research/skills/slurm/clusters/delta.md
+++ b/plugins/ml-research/skills/slurm/clusters/delta.md
@@ -60,11 +60,9 @@ The "CPUs/GPU break-even" column is the largest `--cpus-per-task` per GPU at whi
 
 The `Charge Factor` column in the partition table above is the *GPU-dominant* equivalent (1 SU = 1 A100·hour with GPU dominant; H200 charges 3× when GPU dominates). A job that over-requests CPU exceeds it.
 
-### ACCESS allocation accounting
+### ACCESS portal mapping
 
-ACCESS-portal "Delta GPU Hours" are denominated in A100 (`gpuA100x4`) GPU-hour equivalents: **1 ACCESS GPU-hour = 60,000 billing-units** (matches `gpuA100x4`'s `GRES/gpu=1000` × 60 min).
-
-Conversions (assuming GPU dominates):
+Delta is an ACCESS-governed cluster. See `clusters/access.md` for the general framework. Delta-specific conversion: ACCESS-portal "Delta GPU Hours" are normalized to A100 (`gpuA100x4`) GPU-hour equivalents — **1 ACCESS GPU-hour = 60,000 billing-units** (matches `gpuA100x4`'s `GRES/gpu=1000` × 60 min). Per-partition rates assuming GPU dominates:
 
 | Partition | ACCESS GPU-hours per wallclock-hour |
 |---|---:|
@@ -77,15 +75,6 @@ Conversions (assuming GPU dominates):
 | `gpuH200x8-interactive` | 6.0 |
 
 If CPU dominates, multiply CPU weight × cores × 60 ÷ 60,000 instead. Example: H200 with `--cpus-per-task=33` bills 33 × 250 × 60 = 495,000/hour = **8.25 ACCESS GPU-hours** per wallclock-hour, almost 3× the GPU-dominant rate.
-
-To check the project's QOS allocation:
-
-```bash
-sacctmgr show qos <qos> format=Name,GrpTRESMins   # cap, in billing-minutes
-sshare -A <account>                                # cluster-wide and per-user usage
-```
-
-Divide `GrpTRESMins=billing=...` by 60,000 to convert to ACCESS GPU-hours.
 
 ## Job priority on Delta
 

--- a/plugins/ml-research/skills/slurm/clusters/delta.md
+++ b/plugins/ml-research/skills/slurm/clusters/delta.md
@@ -23,8 +23,6 @@ You have access to the `gnodes` and `jobinfo` executables provided by [slurm-uti
 
 GPU interconnects: A40 nodes use PCIe Gen4 (no NVLink). Quad A100 nodes have NV4 (4-way NVLink). Octa A100 nodes have NV12. H200 nodes have NV18. More NVLink = faster multi-GPU communication within a node.
 
-Service unit (SU) = 1 GPU-hour. Each GPU comes bundled with 16 cores and ~62.5 GB RAM (quad nodes) or 250 GB RAM (octa nodes). Charges are based on whichever fraction is larger: GPUs requested or memory requested.
-
 Default wall-clock if unspecified: 30 min. Default memory per core: 1000 MB.
 
 Preempt queues guarantee a minimum 10 min run (PreemptExemptTime) plus 5 min grace if SIGTERM is handled.
@@ -36,6 +34,58 @@ Preempt queues guarantee a minimum 10 min run (PreemptExemptTime) plus 5 min gra
 - **A100x8** for large models needing >4 GPUs or >256 GB RAM. 1.5x charge factor.
 - **H200x8** for maximum throughput. 141 GB HBM3e per GPU eliminates most OOM issues. 3.0x charge factor — use only when the speedup justifies the cost.
 - **Preempt variants** at half charge are worth using for any fault-tolerant workload with checkpointing.
+
+## TRES billing rates on Delta
+
+Delta sets `PriorityFlags=MAX_TRES` (verify with `scontrol show config | grep PriorityFlags`), so a job's billing rate is determined by its **single dominant TRES**, not the sum. See SKILL.md's "TRES billing rates" section for the general framework.
+
+Per-partition `TRESBillingWeights`, in billing-units per minute (from `scontrol show partition`):
+
+| Partition | CPU | Mem | GRES/gpu | CPUs/GPU break-even |
+|---|---:|---:|---:|---:|
+| `gpuA40x4` | 31.25 | 8G | 500 | 16 |
+| `gpuA40x4-preempt` | 15.625 | 4G | 250 | 16 |
+| `gpuA40x4-interactive` | 62.5 | 16G | 1000 | 16 |
+| `gpuA100x4` | 62.5 | 16G | 1000 | 16 |
+| `gpuA100x4-preempt` | 31.25 | 8G | 500 | 16 |
+| `gpuA100x4-interactive` | 125 | 32G | 2000 | 16 |
+| `gpuA100x8` | 93.75 | 6G | 1500 | 16 |
+| `gpuA100x8-interactive` | 187.5 | 12G | 3000 | 16 |
+| `gpuH200x8` | 250 | 12G | 3000 | **12** |
+| `gpuH200x8-interactive` | 500 | 24G | 6000 | **12** |
+| `gpuMI100x8` | 15.625 | 1G | 250 | 16 |
+| `gpuMI100x8-interactive` | 31.25 | 2G | 500 | 16 |
+
+The "CPUs/GPU break-even" column is the largest `--cpus-per-task` per GPU at which GPU still dominates over CPU (= `GRES/gpu ÷ CPU`). Above it, CPU dominates and the rate scales with cores instead of GPUs. **The H200 partitions break even at 12, not 16** — even though each node has 96 cores / 8 GPUs = 12 cores/GPU available, the bundled-cores ratio matches the billing break-even, so requesting all 12 cores is the sweet spot. Memory weights are loose enough on every partition (per-GPU break-even is in the multi-TB range) that memory effectively never dominates on Delta.
+
+The `Charge Factor` column in the partition table above is the *GPU-dominant* equivalent (1 SU = 1 A100·hour with GPU dominant; H200 charges 3× when GPU dominates). A job that over-requests CPU exceeds it.
+
+### ACCESS allocation accounting
+
+ACCESS-portal "Delta GPU Hours" are denominated in A100 (`gpuA100x4`) GPU-hour equivalents: **1 ACCESS GPU-hour = 60,000 billing-units** (matches `gpuA100x4`'s `GRES/gpu=1000` × 60 min).
+
+Conversions (assuming GPU dominates):
+
+| Partition | ACCESS GPU-hours per wallclock-hour |
+|---|---:|
+| `gpuA40x4` | 0.5 |
+| `gpuA40x4-preempt` | 0.25 |
+| `gpuA100x4` | 1.0 |
+| `gpuA100x4-preempt` | 0.5 |
+| `gpuA100x8` | 1.5 |
+| `gpuH200x8` | **3.0** |
+| `gpuH200x8-interactive` | 6.0 |
+
+If CPU dominates, multiply CPU weight × cores × 60 ÷ 60,000 instead. Example: H200 with `--cpus-per-task=33` bills 33 × 250 × 60 = 495,000/hour = **8.25 ACCESS GPU-hours** per wallclock-hour, almost 3× the GPU-dominant rate.
+
+To check the project's QOS allocation:
+
+```bash
+sacctmgr show qos <qos> format=Name,GrpTRESMins   # cap, in billing-minutes
+sshare -A <account>                                # cluster-wide and per-user usage
+```
+
+Divide `GrpTRESMins=billing=...` by 60,000 to convert to ACCESS GPU-hours.
 
 ## Job priority on Delta
 


### PR DESCRIPTION
## Summary
- Add a generic "TRES billing rates" section to `slurm/SKILL.md`: explains `TRESBillingWeights`, the difference between `MAX_TRES` and SUM combination modes, the memory-suffix divisor convention, a worked example, and how this surfaces as `QOSGrpBillingMinutes`.
- Add a Delta-specific section to `clusters/delta.md`: per-partition weights pulled from `scontrol show partition`, CPUs/GPU break-even points (12 on H200, 16 elsewhere), and the conversion table between billing-units, ACCESS-portal "GPU Hours", and the existing `Charge Factor` column.
- Add a CHPC section to `clusters/chpc.md` pointing to the inspection commands without fabricating per-partition weights, since CHPC numbers vary by cluster and weren't directly verified.

Motivation: a job pending with `Reason=QOSGrpBillingMinutes` led to figuring out that the project's H200 job was being billed at 8.25 ACCESS GPU-hours/wallclock-hour because CPU dominated billing on `gpuH200x8` (33 cores × 250 weight > 1 GPU × 3000 weight). The skill previously framed billing as a single per-partition multiplier, which obscures this case.

## Test plan
- [ ] Read SKILL.md's new section end-to-end and verify it makes sense without prior context.
- [ ] Sanity-check the Delta weights table by spot-running `scontrol show partition gpuH200x8 | grep TRESBillingWeights` etc.
- [ ] Confirm the worked example's arithmetic (33 × 250 = 8250) and the ACCESS conversion (1 ACCESS GPU-hour ≈ 60,000 billing-units, derived from `gpuA100x4`'s `GRES/gpu=1000`/min × 60).
- [ ] Optional: verify the CHPC framing (free vs. allocated partitions) with someone who actively uses notchpeak-gpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)